### PR TITLE
Fix collect when given similar name

### DIFF
--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -270,13 +270,13 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
     # Read data from the first file
     f = getDataFile(0)
 
-    dimensions = f.dimensions(varname)
-
     if varname not in f.keys():
         if strict:
             raise ValueError("Variable '{}' not found".format(varname))
         else:
             varname = findVar(varname, f.list())
+
+    dimensions = f.dimensions(varname)
 
     var_attributes = f.attributes(varname)
     ndims = len(dimensions)


### PR DESCRIPTION
If the variable name differs in case, or is a unique abbreviation of a variable in the file, collect should use the corrected variable. This functionality was broken at some point; this PR fixes it.

Same as https://github.com/boutproject/BOUT-dev/pull/1966