### PR TITLE
Support FieldPerp in restart.redistribute()

### DIFF
--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -237,7 +237,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
         if dimensions == ():
             ranges = []
-        elif dimensions == ('t'):
+        elif dimensions == ('t',):
             ranges = [tind]
         elif dimensions == ('x', 'y'):
             # Field2D

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -235,7 +235,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
         if not yguards:
             yind = slice(yind.start+myg, yind.stop+myg, yind.step)
 
-        if len(dimensions) == ():
+        if dimensions == ():
             ranges = []
         elif dimensions == ('t'):
             ranges = [tind]

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -719,7 +719,8 @@ def resizeY(newy, path="data", output=".", informat="nc", outformat=None, myg=2)
         varnames = infile.list()
 
         for var in varnames:
-            if infile.ndims(var) == 3:
+            dimensions = infile.dimensions(var)
+            if dimensions == ('x', 'y', 'z'):
                 # Could be an evolving variable [x,y,z]
 
                 print(" -> Resizing " + var)
@@ -742,7 +743,7 @@ def resizeY(newy, path="data", output=".", informat="nc", outformat=None, myg=2)
                         outdata[x, :, z] = f(outy)
 
                 outfile.write(var, outdata)
-            elif infile.ndims(var) == 2:
+            elif dimensions == ('x', 'y'):
                 # Assume evolving variable [x,y]
                 print(" -> Resizing " + var)
 


### PR DESCRIPTION
Also simplify restart.redistribute() by using collect() to read from the original set of restart files.

Sorry, I forgot to copy these updates over from https://github.com/boutproject/BOUT-dev/pull/1699/files#diff-68af166dafa001ad8801ac4c92d14b9e.