### PR TITLE
Make BoutOptions.__contains__() case-insensitive

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -110,6 +110,13 @@ class BoutOptions(object):
             return
         self._keys[key.lower()] = value
 
+    def __contains__(self, key):
+        """
+        Check if a key is in the section
+        """
+        key = key.lower()
+        return key in self._sections or key in self._keys
+
     def path(self):
         """Returns the path of this section, joining together names of
         parents


### PR DESCRIPTION
`BoutOptions.__getitem__()` and `BoutOptions.__setitem__()` convert all keys to lower case, to be consistent with case-insensitivity of option names in BOUT++. `__contains__()` should do the same thing so that this works:
```
opt = BoutOptions()
opt["MyOption"] = 1 # "MyOption" converted to lower-case internally
if "myoption" in opt:
    print("should be true")
if "MyOption" in opt:
    print("should also be true")
```
previously the *second* one `"MyOption" in opt` would be `False`, which is confusing!