### PR TITLE
__eq__() comparison operator for BoutOptions()

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -162,6 +162,9 @@ class BoutOptions(object):
         """
         if not isinstance(other, BoutOptions):
             return False
+        if self is other:
+            # other is a reference to the same object
+            return True
         if len(self._sections) != len(other._sections):
             return False
         if len(self._keys) != len(other._keys):

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -157,9 +157,7 @@ class BoutOptions(object):
         return len(self._sections) + len(self._keys)
 
     def __eq__(self, other):
-        """Test if this BoutOptions is the same as another one
-
-        """
+        """Test if this BoutOptions is the same as another one."""
         if not isinstance(other, BoutOptions):
             return False
         if self is other:

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -156,6 +156,24 @@ class BoutOptions(object):
     def __len__(self):
         return len(self._sections) + len(self._keys)
 
+    def __eq__(self, other):
+        """Test if this BoutOptions is the same as another one
+
+        """
+        if not isinstance(other, BoutOptions):
+            return False
+        if len(self._sections) != len(other._sections):
+            return False
+        if len(self._keys) != len(other._keys):
+            return False
+        for secname, section in self._sections.items():
+            if secname not in other or section != other[secname]:
+                return False
+        for key, value in self._keys.items():
+            if key not in other or value != other[key]:
+                return False
+        return True
+
     def __iter__(self):
         """Iterates over all keys. First values, then sections
 


### PR DESCRIPTION
Useful for xBOUT - there the options are saved in an attribute as a `BoutOptions` object. Binary operations sometimes need to compare the attributes of the inputs to check that they are the same so can be used for the result. Without this operator, that check usually fails.