### PR TITLE
Get version number automatically from latest tag

### DIFF
--- a/boutdata/__init__.py
+++ b/boutdata/__init__.py
@@ -10,5 +10,23 @@ from boutdata.collect import collect, attributes
 
 __all__ = ["attributes", "collect", "gen_surface", "pol_slice"]
 
-__version__ = '0.1.3'
 __name__ = 'boutdata'
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    from importlib_metadata import version, PackageNotFoundError
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    try:
+        from setuptools_scm import get_version
+    except ModuleNotFoundError as e:
+        error_info = (
+            "'setuptools_scm' is required to get the version number when running "
+            "boutdata from the git repo. Please install 'setuptools_scm'."
+        )
+        print(error_info)
+        raise ModuleNotFoundError(str(e) + ". " + error_info)
+    else:
+        __version__ = get_version(root="..", relative_to=__file__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.setuptools_scm]
+write_to = "boutdata/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ numpy==1.18.2
 setuptools==46.1.3
 matplotlib==3.2.1
 scipy==1.4.1
+setuptools_scm==5.0.1
 boututils

--- a/setup.py
+++ b/setup.py
@@ -10,22 +10,11 @@ root_path = Path(__file__).parent
 init_path = root_path.joinpath(name, '__init__.py')
 readme_path = root_path.joinpath('README.md')
 
-# https://packaging.python.org/guides/single-sourcing-package-version/
-with init_path.open('r') as f:
-    version_file = f.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        version = version_match.group(1)
-    else:
-        raise RuntimeError('Unable to find version string.')
-
 with readme_path.open('r') as f:
     long_description = f.read()
 
 setuptools.setup(
     name=name,
-    version=version,
     author='Ben Dudson et al.',
     description='Python package for collecting BOUT++ data',
     long_description=long_description,
@@ -44,11 +33,16 @@ setuptools.setup(
               'data-extraction',
               'data-analysis',
               'data-visualization'],
+    use_scm_version=True,
+    setup_requires=['setuptools>=42',
+                    'setuptools_scm[toml]>=3.4',
+                    'setuptools_scm_git_archive'],
     install_requires=['sympy',
                       'numpy',
                       'matplotlib',
                       'scipy',
-                      'boututils'],
+                      'boututils',
+                      "importlib-metadata ; python_version<'3.8'"],
     classifiers=[
         'Programming Language :: Python :: 3',
         ('License :: OSI Approved :: '


### PR DESCRIPTION
Uses the setuptools_scm package to automatically get the version number in both installed versions (which don't require setuptools_scm to be installed) and development versions (which do require setuptools_scm).

This is a copy of the automatic-version-numbering that we use in xbout.

Note: PR to #22 because this is an addition to the package-release feature.