### PR TITLE
When getting version with setuptools_scm, resolve __file__ path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
       - libxkbcommon-x11-0
 
 install:
-  - pip install setuptools_scm
+  - pip install setuptools_scm pytest-cov
   - pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ addons:
       - libxkbcommon-x11-0
 
 install:
-  - pip uninstall -y numpy
-  - pip install boutdata
-  - pip install codecov pytest-cov
+  - pip install setuptools_scm
+  - pip install .
 
 script:
   - pytest --cov=./

--- a/boutdata/__init__.py
+++ b/boutdata/__init__.py
@@ -29,4 +29,6 @@ except PackageNotFoundError:
         print(error_info)
         raise ModuleNotFoundError(str(e) + ". " + error_info)
     else:
-        __version__ = get_version(root="..", relative_to=__file__)
+        from pathlib import Path
+        path = Path(__file__).resolve()
+        __version__ = get_version(root="..", relative_to=path)


### PR DESCRIPTION
If symlinks to the boutdata directory are used, they can confuse the version-number finding function. Fix this by using pathlib.Path.resolve() to resolve all symlinks. This is needed for https://github.com/boutproject/BOUT-dev/pull/2196.