### PR TITLE
Fix BoutOptions.rename for case-sensitive renames

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -300,14 +300,24 @@ class BoutOptions(object):
             new_parent, new_child = get_immediate_parent_and_child(new_name)
             old_parent, old_child = get_immediate_parent_and_child(old_name)
 
+            # Did we just add a new section?
+            new_section = len(new_parent[new_child].keys()) == 0
+            # Was it just a change in case?
+            case_change = new_child.lower() == old_child.lower()
+
             # Renaming a child section just within the same parent section, we can preserve the order
-            if new_parent == old_parent and new_child not in old_parent:
+            if (new_parent is old_parent) and (new_section or case_change):
                 # We just put a new section in, but it will have been
                 # added at the end -- remove it so we can actually put
                 # the new section in the same order as the original
-                new_parent.pop(new_child)
-                new_parent._sections = rename_key(new_parent._sections, new_child, old_child)
-                new_parent.comments = rename_key(new_parent.comments, new_child, old_child)
+                if new_section:
+                    new_parent.pop(new_child)
+                new_parent._sections = rename_key(
+                    new_parent._sections, new_child, old_child
+                )
+                new_parent.comments = rename_key(
+                    new_parent.comments, new_child, old_child
+                )
                 new_parent.inline_comments = rename_key(
                     new_parent.inline_comments, new_child, old_child
                 )
@@ -341,9 +351,11 @@ class BoutOptions(object):
             old_parent, old_child = get_immediate_parent_and_child(old_name)
 
             # Renaming a child key just within the same parent section, we can preserve the order
-            if new_parent == old_parent:
+            if new_parent is old_parent:
                 new_parent._keys = rename_key(new_parent._keys, new_child, old_child)
-                new_parent.comments = rename_key(new_parent.comments, new_child, old_child)
+                new_parent.comments = rename_key(
+                    new_parent.comments, new_child, old_child
+                )
                 new_parent.inline_comments = rename_key(
                     new_parent.inline_comments, new_child, old_child
                 )

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -258,18 +258,18 @@ class BoutOptions(object):
             else:
                 getattr(parent, attr)[key] = value
 
+        def check_is_section(parent, path):
+            if path in parent and not isinstance(parent[path], BoutOptions):
+                raise TypeError(
+                    "'{}:{}' already exists and is not a section!".format(
+                        parent._name, path
+                    )
+                )
+
         def ensure_sections(parent, path):
             """Make sure all the components of path in parent are sections
             """
             path_parts = path.split(":", maxsplit=1)
-
-            def check_is_section(parent, path):
-                if path in parent and not isinstance(parent[path], BoutOptions):
-                    raise TypeError(
-                        "'{}:{}' already exists and is not a section!".format(
-                            parent._name, path
-                        )
-                    )
 
             if len(path_parts) > 1:
                 new_parent_name, child_name = path_parts
@@ -278,34 +278,41 @@ class BoutOptions(object):
                 ensure_sections(parent[new_parent_name], child_name)
             else:
                 check_is_section(parent, path)
+                parent.getSection(path)
 
         def rename_key(thing, new_name, old_name):
             """Rename a key in a dict while trying to preserve order, useful for minimising diffs"""
             return {new_name if k == old_name else k: v for k, v in thing.items()}
 
-        def get_immediate_parent(path):
+        def get_immediate_parent_and_child(path):
             """Get the immediate parent of path"""
-            parent = path.rpartition(":")[0]
-            if parent:
-                return self[parent]
-            return self
+            parent, _, child = path.rpartition(":")
+            if parent and parent in self:
+                return self[parent], child
+            return self, path
 
         value = self[old_name]
 
         if isinstance(value, BoutOptions):
             # We're moving a section: make sure we don't clobber existing values
             ensure_sections(self, new_name)
-            parent = get_immediate_parent(new_name)
+
+            new_parent, new_child = get_immediate_parent_and_child(new_name)
+            old_parent, old_child = get_immediate_parent_and_child(old_name)
 
             # Renaming a child section just within the same parent section, we can preserve the order
-            if parent == get_immediate_parent(old_name):
-                parent._sections = rename_key(parent._sections, new_name, old_name)
-                parent.comments = rename_key(parent.comments, new_name, old_name)
-                parent.inline_comments = rename_key(
-                    parent.inline_comments, new_name, old_name
+            if new_parent == old_parent and new_child not in old_parent:
+                # We just put a new section in, but it will have been
+                # added at the end -- remove it so we can actually put
+                # the new section in the same order as the original
+                new_parent.pop(new_child)
+                new_parent._sections = rename_key(new_parent._sections, new_child, old_child)
+                new_parent.comments = rename_key(new_parent.comments, new_child, old_child)
+                new_parent.inline_comments = rename_key(
+                    new_parent.inline_comments, new_child, old_child
                 )
-                parent._comment_whitespace = rename_key(
-                    parent._comment_whitespace, new_name, old_name
+                new_parent._comment_whitespace = rename_key(
+                    new_parent._comment_whitespace, new_child, old_child
                 )
                 return
 
@@ -330,17 +337,18 @@ class BoutOptions(object):
                 old_name
             )
         else:
-            parent = get_immediate_parent(new_name)
+            new_parent, new_child = get_immediate_parent_and_child(new_name)
+            old_parent, old_child = get_immediate_parent_and_child(old_name)
 
             # Renaming a child key just within the same parent section, we can preserve the order
-            if parent == get_immediate_parent(old_name):
-                parent._keys = rename_key(parent._keys, new_name, old_name)
-                parent.comments = rename_key(parent.comments, new_name, old_name)
-                parent.inline_comments = rename_key(
-                    parent.inline_comments, new_name, old_name
+            if new_parent == old_parent:
+                new_parent._keys = rename_key(new_parent._keys, new_child, old_child)
+                new_parent.comments = rename_key(new_parent.comments, new_child, old_child)
+                new_parent.inline_comments = rename_key(
+                    new_parent.inline_comments, new_child, old_child
                 )
-                parent._comment_whitespace = rename_key(
-                    parent._comment_whitespace, new_name, old_name
+                new_parent._comment_whitespace = rename_key(
+                    new_parent._comment_whitespace, new_child, old_child
                 )
                 return
 

--- a/boutdata/tests/test_boutoptions.py
+++ b/boutdata/tests/test_boutoptions.py
@@ -89,6 +89,16 @@ def test_rename_value_case_sensitive():
     assert options.as_dict() == expected
 
 
+def test_rename_section_case_sensitive():
+    options = BoutOptions()
+    options["lower:a"] = 0
+
+    options.rename("lower", "LOWER")
+
+    expected = {"LOWER": {"a": 0}}
+    assert options.as_dict() == expected
+
+
 def test_rename_section_deeper():
     options = BoutOptions()
     options["top-level value"] = 0

--- a/boutdata/tests/test_boutoptions.py
+++ b/boutdata/tests/test_boutoptions.py
@@ -1,0 +1,212 @@
+from boutdata.data import BoutOptions
+
+import textwrap
+
+
+def test_getSection_nonexistent():
+    options = BoutOptions()
+    options.getSection("new")
+    assert "new" in options
+
+
+def test_get_set_item_value():
+    options = BoutOptions()
+    options["new"] = 5
+    assert options["new"] == 5
+
+
+def test_get_set_item_section():
+    options = BoutOptions()
+    options["section:new"] = 6
+    assert "section" in options
+    assert options["section"]["new"] == 6
+
+
+def test_contains():
+    options = BoutOptions()
+    options["a:b:c"] = 42
+
+    assert "a" in options
+    assert "a:b" in options
+    assert "a:b:c" in options
+    assert "abc" not in options
+
+
+def test_as_dict():
+    options = BoutOptions()
+    options["section:new"] = 7
+    expected = {"section": {"new": 7}}
+    assert options.as_dict() == expected
+
+
+def test_rename_section_same_level():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section")
+    section["first"] = 1
+    section["second"] = 2
+    options["other top-level"] = 3
+
+    options.rename("section", "another")
+
+    expected = {
+        "top-level value": 0,
+        "another": {"first": 1, "second": 2},
+        "other top-level": 3,
+    }
+    assert "another" in options
+    assert "section" not in options
+    assert options.as_dict() == expected
+
+
+def test_rename_value_same_level():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section")
+    section["first"] = 1
+    section["second"] = 2
+    options["other top-level"] = 3
+
+    options.rename("section:first", "section:third")
+
+    expected = {
+        "top-level value": 0,
+        "section": {"third": 1, "second": 2},
+        "other top-level": 3,
+    }
+    assert "section:third" in options
+    assert "section:first" not in options
+    assert options.as_dict() == expected
+
+
+def test_rename_value_case_sensitive():
+    options = BoutOptions()
+    options["lower"] = 0
+
+    options.rename("lower", "LOWER")
+
+    expected = {"LOWER": 0}
+    assert options.as_dict() == expected
+
+
+def test_rename_section_deeper():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section")
+    section["first"] = 1
+    section["second"] = 2
+    options["other top-level"] = 3
+
+    options.rename("section", "another:layer")
+
+    expected = {
+        "top-level value": 0,
+        "another": {
+            "layer": {"first": 1, "second": 2},
+        },
+        "other top-level": 3,
+    }
+    assert "another" in options
+    assert "section" not in options
+    assert options.as_dict() == expected
+
+
+def test_rename_section_into_other_section():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section1")
+    section["first"] = 1
+    section["second"] = 2
+    section2 = options.getSection("section2")
+    section2["third"] = 3
+    section2["fourth"] = 4
+    options["other top-level"] = 5
+
+    options.rename("section1", "section2")
+
+    expected = {
+        "top-level value": 0,
+        "section2": {"first": 1, "second": 2, "third": 3, "fourth": 4},
+        "other top-level": 5,
+    }
+    assert options.as_dict() == expected
+    assert "section2:third" in options
+    assert "section1:first" not in options
+
+
+def test_rename_value_deeper():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section")
+    section["first"] = 1
+    section["second"] = 2
+    options["other top-level"] = 3
+
+    options.rename("section:first", "section:subsection:first")
+
+    expected = {
+        "top-level value": 0,
+        "section": {
+            "second": 2,
+            "subsection": {"first": 1},
+        },
+        "other top-level": 3,
+    }
+    assert "section:subsection:first" in options
+    assert "section:first" not in options
+    assert options.as_dict() == expected
+
+
+def test_rename_value_into_other_section():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section1")
+    section["first"] = 1
+    section["second"] = 2
+    section2 = options.getSection("section2")
+    section2["third"] = 3
+    section2["fourth"] = 4
+    options["other top-level"] = 5
+
+    options.rename("section1:first", "section2:first")
+
+    expected = {
+        "top-level value": 0,
+        "section1": {"second": 2},
+        "section2": {"first": 1, "third": 3, "fourth": 4},
+        "other top-level": 5,
+    }
+    assert options.as_dict() == expected
+    assert "section2:third" in options
+    assert "section1:first" not in options
+
+
+def test_path():
+    options = BoutOptions("top level")
+    options["a:b:c:d"] = 1
+    section = options.getSection("a:b:c")
+
+    assert section.path() == "top level:a:b:c"
+
+
+def test_str():
+    options = BoutOptions()
+    options["top-level value"] = 0
+    section = options.getSection("section")
+    section["first"] = 1
+    section["second"] = 2
+    options["other top-level"] = 3
+
+    # lstrip to remove the first empty line
+    expected = textwrap.dedent(
+        """
+        top-level value = 0
+        other top-level = 3
+
+        [section]
+        first = 1
+        second = 2
+        """
+    ).lstrip()
+
+    assert str(options) == expected


### PR DESCRIPTION
Also try to preserve order of same-level renames to minimise diffs