### PR TITLE
BoutOptions.get_bool() method to convert option value to bool

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -491,8 +491,10 @@ class BoutOptions(object):
         """
         Convert an option value to a bool, in (almost) the same way as BOUT++.
 
-        Note BOUT++ will convert any option value beginning with "y", "Y", "t", "T" or
-        "1" to True, and any beginning with "n", "N", "f", "F" or "0" to False. Because
+        Warnings
+        --------
+        BOUT++ will convert any option value beginning with "y", "Y", "t", "T" or "1" to
+        True, and any beginning with "n", "N", "f", "F" or "0" to False. Because
         BoutOptions converts option values to int and float, this method cannot be quite
         so permissive, and will raise an exception for ints other than 0 and 1 and for
         floats, which BOUT++ might convert to a bool.

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -487,6 +487,47 @@ class BoutOptions(object):
 
         return f.getvalue()
 
+    def get_bool(self, name, default=None):
+        """
+        Convert an option value to a bool, in (almost) the same way as BOUT++.
+
+        Note BOUT++ will convert any option value beginning with "y", "Y", "t", "T" or
+        "1" to True, and any beginning with "n", "N", "f", "F" or "0" to False. Because
+        BoutOptions converts option values to int and float, this method cannot be quite
+        so permissive, and will raise an exception for ints other than 0 and 1 and for
+        floats, which BOUT++ might convert to a bool.
+
+        Parameters
+        ----------
+        name : str
+            The name of the option to read
+        default : bool, optional
+            Value to return if the option is not present. If default is not provided an
+            exception will be raised if the option is not present.
+        """
+        if default is not None and not isinstance(default, bool):
+            raise ValueError(f'default "{default}" is not a bool')
+
+        try:
+            value = self[name]
+        except KeyError:
+            if default is None:
+                raise
+            else:
+                return default
+
+        def test_first(s, testvals):
+            if isinstance(s, str):
+                return s[0] in tuple(testvals)
+            return False
+
+        if value == 1 or test_first(value, ("y", "Y", "t", "T", "1")):
+            return True
+        elif value == 0 or test_first(value, ("n", "N", "f", "F", "0")):
+            return False
+
+        raise ValueError(f"Could not convert {name}={value} to a bool")
+
     def evaluate_scalar(self, name):
         """
         Evaluate (recursively) scalar expressions

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -516,14 +516,13 @@ class BoutOptions(object):
             else:
                 return default
 
-        def test_first(s, testvals):
-            if isinstance(s, str):
-                return s[0] in tuple(testvals)
-            return False
-
-        if value == 1 or test_first(value, ("y", "Y", "t", "T", "1")):
+        if value == 1 or (
+            isinstance(value, str) and value.lower() in ("y", "yes", "t", "true")
+        ):
             return True
-        elif value == 0 or test_first(value, ("n", "N", "f", "F", "0")):
+        elif value == 0 or (
+            isinstance(value, str) and value.lower() in ("n", "no", "f", "false")
+        ):
             return False
 
         raise ValueError(f"Could not convert {name}={value} to a bool")

--- a/boutdata/tests/test_boutoptions.py
+++ b/boutdata/tests/test_boutoptions.py
@@ -226,22 +226,7 @@ def test_str():
 def test_get_bool():
     options = BoutOptions()
 
-    for truelike in [
-        "y",
-        "Y",
-        "yes",
-        "Yes",
-        "t",
-        "T",
-        "true",
-        "True",
-        "yaihets",
-        "Yaxfus",
-        "tueoxg",
-        "Teouaig",
-        1,
-        "1uegxa",
-    ]:
+    for truelike in ["y", "Y", "yes", "Yes", "t", "T", "true", "True", 1]:
         options["truevalue"] = truelike
         assert options.get_bool("truevalue") is True
         assert options.get_bool("truevalue", True) is True
@@ -249,22 +234,7 @@ def test_get_bool():
         with pytest.raises(ValueError):
             options.get_bool("truevalue", "not a bool")
 
-    for falseelike in [
-        "n",
-        "N",
-        "no",
-        "No",
-        "f",
-        "F",
-        "false",
-        "False",
-        "naihets",
-        "Naxfus",
-        "fueoxg",
-        "Feouaig",
-        0,
-        "0uegxa",
-    ]:
+    for falseelike in ["n", "N", "no", "No", "f", "F", "false", "False", 0]:
         options["falseevalue"] = falseelike
         assert options.get_bool("falseevalue") is False
         assert options.get_bool("falseevalue", True) is False
@@ -279,10 +249,23 @@ def test_get_bool():
     with pytest.raises(ValueError):
         options.get_bool("missingoption", "not a bool")
 
-    options["stringvalue"] = "bar"
-    with pytest.raises(ValueError):
-        options.get_bool("stringvalue")
-    with pytest.raises(ValueError):
-        options.get_bool("stringvalue", True)
-    with pytest.raises(ValueError):
-        options.get_bool("stringvalue", False)
+    for invalid in [
+        "bar",
+        "yaihets",
+        "Yaxfus",
+        "tueoxg",
+        "Teouaig",
+        "1uegxa",
+        "naihets",
+        "Naxfus",
+        "fueoxg",
+        "Feouaig",
+        "0uegxa",
+    ]:
+        options["stringvalue"] = invalid
+        with pytest.raises(ValueError):
+            options.get_bool("stringvalue")
+        with pytest.raises(ValueError):
+            options.get_bool("stringvalue", True)
+        with pytest.raises(ValueError):
+            options.get_bool("stringvalue", False)

--- a/boutdata/tests/test_boutoptions.py
+++ b/boutdata/tests/test_boutoptions.py
@@ -1,5 +1,6 @@
 from boutdata.data import BoutOptions
 
+import pytest
 import textwrap
 
 
@@ -220,3 +221,68 @@ def test_str():
     ).lstrip()
 
     assert str(options) == expected
+
+
+def test_get_bool():
+    options = BoutOptions()
+
+    for truelike in [
+        "y",
+        "Y",
+        "yes",
+        "Yes",
+        "t",
+        "T",
+        "true",
+        "True",
+        "yaihets",
+        "Yaxfus",
+        "tueoxg",
+        "Teouaig",
+        1,
+        "1uegxa",
+    ]:
+        options["truevalue"] = truelike
+        assert options.get_bool("truevalue") is True
+        assert options.get_bool("truevalue", True) is True
+        assert options.get_bool("truevalue", False) is True
+        with pytest.raises(ValueError):
+            options.get_bool("truevalue", "not a bool")
+
+    for falseelike in [
+        "n",
+        "N",
+        "no",
+        "No",
+        "f",
+        "F",
+        "false",
+        "False",
+        "naihets",
+        "Naxfus",
+        "fueoxg",
+        "Feouaig",
+        0,
+        "0uegxa",
+    ]:
+        options["falseevalue"] = falseelike
+        assert options.get_bool("falseevalue") is False
+        assert options.get_bool("falseevalue", True) is False
+        assert options.get_bool("falseevalue", False) is False
+        with pytest.raises(ValueError):
+            options.get_bool("falsevalue", 1)
+
+    with pytest.raises(KeyError):
+        options.get_bool("missingoption")
+    assert options.get_bool("missingoption", True) is True
+    assert options.get_bool("missingoption", False) is False
+    with pytest.raises(ValueError):
+        options.get_bool("missingoption", "not a bool")
+
+    options["stringvalue"] = "bar"
+    with pytest.raises(ValueError):
+        options.get_bool("stringvalue")
+    with pytest.raises(ValueError):
+        options.get_bool("stringvalue", True)
+    with pytest.raises(ValueError):
+        options.get_bool("stringvalue", False)


### PR DESCRIPTION
Cannot automatically convert option values to `bool` in the same way BOUT++ does because string options might be converted incorrectly. Instead provide a `BoutOptions.get_bool()` method to apply (almost) the same conversion as BOUT++ does.

Closes #32.