### PR TITLE
Set netCDF's 'chunk cache' to zero in squashoutput

### DIFF
--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -75,6 +75,16 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
     delete : bool
         Delete the original files after squashing.
     """
+    try:
+        # If we are using the netCDF4 module (the usual case) set caching to zero, since
+        # each variable is read and written exactly once so caching does not help, only
+        # uses memory - for large data sets, the memory usage may become excessive.
+        from netCDF4 import get_chunk_cache, set_chunk_cache
+    except ImportError:
+        netcdf4_chunk_cache = None
+    else:
+        netcdf4_chunk_cache = get_chunk_cache()
+        set_chunk_cache(0)
 
     fullpath = os.path.join(datadir, outputname)
 
@@ -158,3 +168,7 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
             os.remove(f)
         if append:
             os.rmdir(datadir)
+
+    if netcdf4_chunk_cache is not None:
+        # Reset the default chunk_cache size that was changed for squashoutput
+        set_chunk_cache(netcdf4_chunk_cache)

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -171,4 +171,6 @@ def squashoutput(datadir=".", outputname="BOUT.dmp.nc", format="NETCDF4", tind=N
 
     if netcdf4_chunk_cache is not None:
         # Reset the default chunk_cache size that was changed for squashoutput
-        set_chunk_cache(netcdf4_chunk_cache)
+        # Note that get_chunk_cache() returns a tuple, so we have to unpack it when
+        # passing to set_chunk_cache.
+        set_chunk_cache(*netcdf4_chunk_cache)


### PR DESCRIPTION
netCDF uses a 'chunk cache' to speed up repeated reads. `squashoutput()` only reads each variable once, so the cache does not help, but may use a large amount of memory in some cases, so set it to zero for the duration of squashoutput.