### PR TITLE
Tests for collect and squashoutput

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test local run
         run: |
-          pytest --cov=./
+          pytest -v --cov=./
 
       - name: Upload to codecov
         run: |

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -604,11 +604,19 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
                     # we have found a file with containing the FieldPerp, get the attributes from here
                     var_attributes = f_attributes
-                assert temp_yindex == yindex_global
+                if temp_yindex != yindex_global:
+                    raise ValueError(
+                        "Found FieldPerp {} at different global y-indices, {} and {}"
+                        .format(varname, temp_yindex, yindex_global)
+                    )
 
             if temp_yindex >= 0:
                 # Check we only read from one pe_yind
-                assert fieldperp_yproc is None or fieldperp_yproc == pe_yind
+                if not (fieldperp_yproc is None or fieldperp_yproc == pe_yind):
+                    raise ValueError(
+                        "Found FieldPerp {} on different y-processor indices, {} and {}"
+                        .format(varname, fieldperp_yproc, pe_yind)
+                    )
 
                 fieldperp_yproc = pe_yind
 
@@ -632,11 +640,19 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
                     # we have found a file with containing the FieldPerp, get the attributes from here
                     var_attributes = f_attributes
-                assert temp_yindex == yindex_global
+                if temp_yindex != yindex_global:
+                    raise ValueError(
+                        "Found FieldPerp {} at different global y-indices, {} and {}"
+                        .format(varname, temp_yindex, yindex_global)
+                    )
 
             if temp_yindex >= 0:
                 # Check we only read from one pe_yind
-                assert fieldperp_yproc is None or fieldperp_yproc == pe_yind
+                if not (fieldperp_yproc is None or fieldperp_yproc == pe_yind):
+                    raise ValueError(
+                        "Found FieldPerp {} on different y-processor indices, {} and {}"
+                        .format(varname, fieldperp_yproc, pe_yind)
+                    )
 
                 fieldperp_yproc = pe_yind
 

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -1,0 +1,301 @@
+from copy import copy
+from netCDF4 import Dataset
+import numpy as np
+
+# Note "yindex_global" attribute not included here for FieldPerps, because it is handled
+# specially
+expected_attributes = {
+    "field3d_t_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "field3d_t_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "field3d_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "field3d_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "field2d_t_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Average",
+    },
+    "field2d_t_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Average",
+    },
+    "field2d_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Average",
+    },
+    "field2d_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Average",
+    },
+    "fieldperp_t_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "fieldperp_t_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "fieldperp_1": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+    "fieldperp_2": {
+        "cell_location": "CELL_CENTRE",
+        "direction_y": "Standard",
+        "direction_z": "Standard",
+    },
+}
+
+
+def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_yind):
+    """
+    Create a netCDF file mocking up a BOUT++ output file, and also return the data
+    without guard cells
+
+    Parameters
+    ----------
+    i : int
+        Number of the output file
+    tmpdir : pathlib.Path
+    tmpdir : pathlib.Path
+        Directory to write the dump file in
+    rng : numpy.random.Generator
+        Random number generator to create data
+    grid_info : dict
+        Dictionary containing grid sizes, etc
+    boundaries : sequence of str
+        Which edges are boundaries. Should be a sequence containing any of "xinner",
+        "xouter", "ylower" and "yupper".
+    fieldperp_global_yind : int
+        Global y-index for a FieldPerp (should be -1 if FieldPerp is not on this
+        processor).
+
+    Returns
+    -------
+    Dict of scalars and numpy arrays
+    """
+    nt = grid_info["iteration"]
+    mxg = grid_info["MXG"]
+    myg = grid_info["MYG"]
+    mzg = grid_info["MZG"]
+    localnx = grid_info["MXSUB"] + 2 * mxg
+    localny = grid_info["MYSUB"] + 2 * myg
+    localnz = grid_info["MZSUB"] + 2 * mzg
+
+    for b in boundaries:
+        if b not in ("xinner", "xouter", "yupper", "ylower"):
+            raise ValueError("Unexpected boundary input " + str(b))
+    xinner = "xinner" in boundaries
+    xouter = "xouter" in boundaries
+    ylower = "ylower" in boundaries
+    yupper = "yupper" in boundaries
+
+    outputfile = Dataset(tmpdir.joinpath("BOUT.dmp." + str(i) + ".nc"), "w")
+
+    outputfile.createDimension("t", None)
+    outputfile.createDimension("x", localnx)
+    outputfile.createDimension("y", localny)
+    outputfile.createDimension("z", localnz)
+
+    # Create slices for returned data without guard cells
+    xslice = slice(None if xinner else mxg, None if xouter or mxg == 0 else -mxg)
+    yslice = slice(None if ylower else myg, None if yupper or myg == 0 else -myg)
+    zslice = slice(mzg, None if mzg == 0 else -mzg)
+
+    result = {}
+
+    # Field3D
+    def create3D_t(name):
+        var = outputfile.createVariable(name, float, ("t", "x", "y", "z"))
+
+        data = rng.random((nt, localnx, localny, localnz))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+
+        result[name] = data[:, xslice, yslice, zslice]
+
+    create3D_t("field3d_t_1")
+    create3D_t("field3d_t_2")
+
+    def create3D(name):
+        var = outputfile.createVariable(name, float, ("x", "y", "z"))
+
+        data = rng.random((localnx, localny, localnz))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+
+        result[name] = data[xslice, yslice, zslice]
+
+    create3D("field3d_1")
+    create3D("field3d_2")
+
+    # Field2D
+    def create2D_t(name):
+        var = outputfile.createVariable(name, float, ("t", "x", "y"))
+
+        data = rng.random((nt, localnx, localny))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+
+        result[name] = data[:, xslice, yslice]
+
+    create2D_t("field2d_t_1")
+    create2D_t("field2d_t_2")
+
+    def create2D(name):
+        var = outputfile.createVariable(name, float, ("x", "y"))
+
+        data = rng.random((localnx, localny))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+
+        result[name] = data[xslice, yslice]
+
+    create2D("field2d_1")
+    create2D("field2d_2")
+
+    # FieldPerp
+    def createPerp_t(name):
+        var = outputfile.createVariable(name, float, ("t", "x", "z"))
+
+        data = rng.random((nt, localnx, localnz))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+        var.setncattr("yindex_global", fieldperp_global_yind)
+
+        result[name] = data[:, xslice, zslice]
+
+    createPerp_t("fieldperp_t_1")
+    createPerp_t("fieldperp_t_2")
+
+    def createPerp(name):
+        var = outputfile.createVariable(name, float, ("x", "z"))
+
+        data = rng.random((localnx, localnz))
+        var[:] = data
+        for key, value in expected_attributes[name].items():
+            var.setncattr(key, value)
+        var.setncattr("yindex_global", fieldperp_global_yind)
+
+        result[name] = data[xslice, zslice]
+
+    createPerp("fieldperp_1")
+    createPerp("fieldperp_2")
+
+    # Time-dependent array
+    def createScalar_t(name):
+        var = outputfile.createVariable(name, float, ("t",))
+
+        data = rng.random(nt)
+        var[:] = data
+
+        result[name] = data
+
+    createScalar_t("t_array")
+    createScalar_t("scalar_t_1")
+    createScalar_t("scalar_t_2")
+
+    # Scalar
+    def createScalar(name, value):
+        var = outputfile.createVariable(name, type(value))
+
+        var[...] = value
+
+        result[name] = value
+
+    createScalar("BOUT_VERSION", 4.31)
+    for key, value in grid_info.items():
+        createScalar(key, value)
+    nxpe = grid_info["NXPE"]
+    createScalar("PE_XIND", i % nxpe)
+    createScalar("PE_YIND", i // nxpe)
+    createScalar("MYPE", i)
+
+    return result
+
+
+def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
+    # Just keep scalars from root file
+    result = copy(data_list[0])
+    for x in list(result.keys()):
+        if x[:5] == "field":
+            result.pop(x)
+
+    npes = len(data_list)
+    nype = npes // nxpe
+    if npes % nxpe != 0:
+        raise ValueError("nxpe=%i does not divide len(data_list)=%i".format(nxpe, npes))
+
+    for var in ("field3d_t_1", "field3d_t_2", "field2d_t_1", "field2d_t_2"):
+        # Join in x-direction
+        parts = [
+            np.concatenate(
+                [data_list[j][var] for j in range(i * nxpe, (i + 1) * nxpe)], axis=1
+            )
+            for i in range(nype)
+        ]
+        # Join in y-direction
+        result[var] = np.concatenate(parts, axis=2)
+
+    for var in ("field3d_1", "field3d_2", "field2d_1", "field2d_2"):
+        # Join in x-direction
+        parts = [
+            np.concatenate(
+                [data_list[j][var] for j in range(i * nxpe, (i + 1) * nxpe)], axis=0
+            )
+            for i in range(nype)
+        ]
+        # Join in y-direction
+        result[var] = np.concatenate(parts, axis=1)
+
+    for var in ("fieldperp_t_1", "fieldperp_t_2"):
+        # Join in x-direction
+        result[var] = np.concatenate(
+            [
+                data_list[j][var]
+                for j in range(
+                    fieldperp_yproc_ind * nxpe, (fieldperp_yproc_ind + 1) * nxpe
+                )
+            ],
+            axis=1,
+        )
+
+    for var in ("fieldperp_1", "fieldperp_2"):
+        # Join in x-direction
+        result[var] = np.concatenate(
+            [
+                data_list[j][var]
+                for j in range(
+                    fieldperp_yproc_ind * nxpe, (fieldperp_yproc_ind + 1) * nxpe
+                )
+            ],
+            axis=0,
+        )
+
+    return result

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -8,6 +8,7 @@ field2d_t_list = ["field2d_t_1", "field2d_t_2"]
 field2d_list = ["field2d_1", "field2d_2"]
 fieldperp_t_list = ["fieldperp_t_1", "fieldperp_t_2"]
 fieldperp_list = ["fieldperp_1", "fieldperp_2"]
+scalar_t_list = ["t_array", "scalar_t_1", "scalar_t_2"]
 
 # Note "yindex_global" attribute not included here for FieldPerps, because it is handled
 # specially
@@ -306,6 +307,25 @@ def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
         )
 
     return result
+
+
+def apply_slices(expected, tslice, xslice, yslice, zslice):
+    # Note - this should by called after 'xguards' and 'yguards' have been applied to
+    # 'expected'.
+    for varname in field3d_t_list:
+        expected[varname] = expected[varname][tslice, xslice, yslice, zslice]
+    for varname in field3d_list:
+        expected[varname] = expected[varname][xslice, yslice, zslice]
+    for varname in field2d_t_list:
+        expected[varname] = expected[varname][tslice, xslice, yslice]
+    for varname in field2d_list:
+        expected[varname] = expected[varname][xslice, yslice]
+    for varname in fieldperp_t_list:
+        expected[varname] = expected[varname][tslice, xslice, zslice]
+    for varname in fieldperp_list:
+        expected[varname] = expected[varname][xslice, zslice]
+    for varname in scalar_t_list:
+        expected[varname] = expected[varname][tslice]
 
 
 def remove_xboundaries(expected, mxg):

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -86,7 +86,6 @@ def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_
     i : int
         Number of the output file
     tmpdir : pathlib.Path
-    tmpdir : pathlib.Path
         Directory to write the dump file in
     rng : numpy.random.Generator
         Random number generator to create data

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -2,6 +2,13 @@ from copy import copy
 from netCDF4 import Dataset
 import numpy as np
 
+field3d_t_list = ["field3d_t_1", "field3d_t_2"]
+field3d_list = ["field3d_1", "field3d_2"]
+field2d_t_list = ["field2d_t_1", "field2d_t_2"]
+field2d_list = ["field2d_1", "field2d_2"]
+fieldperp_t_list = ["fieldperp_t_1", "fieldperp_t_2"]
+fieldperp_list = ["fieldperp_1", "fieldperp_2"]
+
 # Note "yindex_global" attribute not included here for FieldPerps, because it is handled
 # specially
 expected_attributes = {
@@ -299,3 +306,65 @@ def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
         )
 
     return result
+
+
+def remove_xboundaries(expected, mxg):
+    if mxg == 0:
+        return
+
+    for varname in field3d_t_list + field2d_t_list + fieldperp_t_list:
+        expected[varname] = expected[varname][:, mxg:-mxg]
+
+    for varname in field3d_list + field2d_list + fieldperp_list:
+        expected[varname] = expected[varname][mxg:-mxg]
+
+
+def remove_yboundaries(expected, myg, ny_inner, doublenull):
+    if myg == 0:
+        return
+
+    if doublenull:
+        for varname in field3d_t_list + field2d_t_list:
+            expected[varname] = np.concatenate(
+                [
+                    expected[varname][:, :, myg : ny_inner + myg],
+                    expected[varname][:, :, ny_inner + 3 * myg : -myg],
+                ],
+                axis=2,
+            )
+        for varname in field3d_list + field2d_list:
+            expected[varname] = np.concatenate(
+                [
+                    expected[varname][:, myg : ny_inner + myg],
+                    expected[varname][:, ny_inner + 3 * myg : -myg],
+                ],
+                axis=1,
+            )
+    else:
+        for varname in field3d_t_list + field2d_t_list:
+            expected[varname] = expected[varname][:, :, myg:-myg]
+        for varname in field3d_list + field2d_list:
+            expected[varname] = expected[varname][:, myg:-myg]
+
+
+def remove_yboundaries_upper_divertor(expected, myg, ny_inner):
+    if myg == 0:
+        return
+
+    for varname in field3d_t_list + field2d_t_list:
+        expected[varname] = np.concatenate(
+            [
+                expected[varname][:, :, : ny_inner + myg],
+                expected[varname][:, :, ny_inner + 3 * myg :],
+            ],
+            axis=2,
+        )
+
+    for varname in field3d_list + field2d_list:
+        expected[varname] = np.concatenate(
+            [
+                expected[varname][:, : ny_inner + myg],
+                expected[varname][:, ny_inner + 3 * myg :],
+            ],
+            axis=1,
+        )

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -248,6 +248,21 @@ def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_
 
 
 def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
+    """
+    Joins together lists of data arrays for expected results from each process into a
+    global array.
+
+    Parameters
+    ----------
+    data_list : list of dict of {str: numpy array}
+        List, ordered by processor number, of dicts of expected data (key is name, value
+        is scalar or numpy array of data). Data should not include guard cells.
+    nxpe : int
+        Number of processes in the x-direction.
+    fieldperp_yproc_ind : int
+        y-processes index to keep FieldPerps from. FieldPerps can only be defined at a
+        single global y-index, so should be discarded from other processes.
+    """
     # Just keep scalars from root file
     result = copy(data_list[0])
     for x in list(result.keys()):
@@ -309,6 +324,23 @@ def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
 
 
 def apply_slices(expected, tslice, xslice, yslice, zslice):
+    """
+    Slice expected data
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    tslice : slice object
+        Slice to apply in the t-direction
+    xslice : slice object
+        Slice to apply in the x-direction
+    yslice : slice object
+        Slice to apply in the y-direction
+    zslice : slice object
+        Slice to apply in the z-direction
+    """
     # Note - this should by called after 'xguards' and 'yguards' have been applied to
     # 'expected'.
     for varname in field3d_t_list:
@@ -328,6 +360,17 @@ def apply_slices(expected, tslice, xslice, yslice, zslice):
 
 
 def remove_xboundaries(expected, mxg):
+    """
+    Remove x-boundary points from expected data
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    mxg : int
+        Number of boundary points to remove.
+    """
     if mxg == 0:
         return
 
@@ -339,6 +382,24 @@ def remove_xboundaries(expected, mxg):
 
 
 def remove_yboundaries(expected, myg, ny_inner, doublenull):
+    """
+    Remove y-boundary points from expected data
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    myg : int
+        Number of boundary points to remove.
+    ny_inner : int
+        BOUT++ ny_inner parameter - specifies location of 'upper target' y-boundary for
+        double-null topology
+    doublenull : bool
+        If True the data for double-null. If False the data is for single-null, limiter,
+        core or SOL topologies which do not have a y-boundary in the middle of the
+        domain.
+    """
     if myg == 0:
         return
 
@@ -367,6 +428,21 @@ def remove_yboundaries(expected, myg, ny_inner, doublenull):
 
 
 def remove_yboundaries_upper_divertor(expected, myg, ny_inner):
+    """
+    Remove y-boundary points just from the 'upper divertor' - the y-boundaries in the
+    middle of the domain.
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    myg : int
+        Number of boundary points to remove.
+    ny_inner : int
+        BOUT++ ny_inner parameter - specifies location of 'upper target' y-boundary for
+        double-null topology
+    """
     if myg == 0:
         return
 

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -891,3 +891,723 @@ class TestCollect:
             collect_kwargs=collect_kwargs,
             squash_kwargs=squash_kwargs,
         )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_connected_doublenull_min_files(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 6
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 4
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 2 * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 3 * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 4 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 5 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 7
+        fieldperp_yproc_ind = 1
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # inner, lower divertor leg
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # inner core
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+
+        # inner, upper divertor leg
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer, upper divertor leg
+        dumps.append(
+            create_dump_file(
+                i=3,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer core
+        dumps.append(
+            create_dump_file(
+                i=4,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer, lower divertor leg
+        dumps.append(
+            create_dump_file(
+                i=5,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_connected_doublenull(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 18
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 7
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # inner, lower divertor leg
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=3,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=4,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=5,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=6,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=7,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=8,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # inner core
+        dumps.append(
+            create_dump_file(
+                i=9,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=10,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=11,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=12,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=13,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=14,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=15,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=16,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=17,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # inner, upper divertor leg
+        dumps.append(
+            create_dump_file(
+                i=18,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=19,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=20,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=21,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=22,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=23,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=24,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=25,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=26,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer, upper divertor leg
+        dumps.append(
+            create_dump_file(
+                i=27,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=28,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=29,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=30,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=31,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=32,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=33,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=34,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=35,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer core
+        dumps.append(
+            create_dump_file(
+                i=36,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=37,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=38,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=39,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=40,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=41,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=42,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=43,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=44,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer, lower divertor leg
+        dumps.append(
+            create_dump_file(
+                i=45,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=46,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=47,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=48,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=49,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=50,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=51,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=52,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=53,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -215,20 +215,18 @@ class TestCollect:
         # core includes "ylower" and "yupper" even though there is no actual y-boundary
         # because collect/squashoutput collect these points
         dump_params = [
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower", "yupper"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (0, ["xinner", "xouter", "ylower", "yupper"], fieldperp_global_yind),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -264,60 +262,26 @@ class TestCollect:
         # core includes "ylower" and "yupper" even though there is no actual y-boundary
         # because collect/squashoutput collect these points
         dump_params = [
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], fieldperp_global_yind),
+            (1, ["ylower"], fieldperp_global_yind),
+            (2, ["xouter", "ylower"], fieldperp_global_yind),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner", "yupper"], -1),
+            (7, ["yupper"], -1),
+            (8, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -349,20 +313,18 @@ class TestCollect:
 
         # SOL
         dump_params = [
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower", "yupper"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (0, ["xinner", "xouter", "ylower", "yupper"], fieldperp_global_yind),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -396,60 +358,26 @@ class TestCollect:
 
         # SOL
         dump_params = [
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], fieldperp_global_yind),
+            (1, ["ylower"], fieldperp_global_yind),
+            (2, ["xouter", "ylower"], fieldperp_global_yind),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner", "yupper"], -1),
+            (7, ["yupper"], -1),
+            (8, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -481,32 +409,22 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "xouter", "ylower"], -1),
             # core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (1, ["xinner", "xouter"], fieldperp_global_yind),
             # outer divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -541,32 +459,22 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (0, ["xinner", "xouter", "ylower"], fieldperp_global_yind),
             # core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (1, ["xinner", "xouter"], -1),
             # outer divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -601,32 +509,22 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "xouter", "ylower"], -1),
             # core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (1, ["xinner", "xouter"], -1),
             # outer divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (2, ["xinner", "xouter", "yupper"], fieldperp_global_yind),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -663,32 +561,22 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": 2,
-            },
+            (0, ["xinner", "xouter", "ylower"], 2),
             # core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": 7,
-            },
+            (1, ["xinner", "xouter"], 7),
             # outer divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -726,32 +614,22 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": 7,
-            },
+            (0, ["xinner", "xouter", "ylower"], 7),
             # core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": 7,
-            },
+            (1, ["xinner", "xouter"], 7),
             # outer divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -786,152 +664,46 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], -1),
+            (1, ["ylower"], -1),
+            (2, ["xouter", "ylower"], -1),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner"], -1),
+            (7, [], -1),
+            (8, ["xouter"], -1),
             # core
-            {
-                "i": 9,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 10,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 11,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 12,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 13,
-                "boundaries": [],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 14,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 15,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 16,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 17,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (9, ["xinner"], -1),
+            (10, [], -1),
+            (11, ["xouter"], -1),
+            (12, ["xinner"], fieldperp_global_yind),
+            (13, [], fieldperp_global_yind),
+            (14, ["xouter"], fieldperp_global_yind),
+            (15, ["xinner"], -1),
+            (16, [], -1),
+            (17, ["xouter"], -1),
             # outer divertor leg
-            {
-                "i": 18,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 19,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 20,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 21,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 22,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 23,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 24,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 25,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 26,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (18, ["xinner"], -1),
+            (19, [], -1),
+            (20, ["xouter"], -1),
+            (21, ["xinner"], -1),
+            (22, [], -1),
+            (23, ["xouter"], -1),
+            (24, ["xinner", "yupper"], -1),
+            (25, ["yupper"], -1),
+            (26, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -1324,152 +1096,46 @@ class TestCollect:
 
         dump_params = [
             # inner divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], -1),
+            (1, ["ylower"], -1),
+            (2, ["xouter", "ylower"], -1),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner"], -1),
+            (7, [], -1),
+            (8, ["xouter"], -1),
             # core
-            {
-                "i": 9,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 10,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 11,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 12,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 13,
-                "boundaries": [],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 14,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 15,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 16,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 17,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (9, ["xinner"], -1),
+            (10, [], -1),
+            (11, ["xouter"], -1),
+            (12, ["xinner"], fieldperp_global_yind),
+            (13, [], fieldperp_global_yind),
+            (14, ["xouter"], fieldperp_global_yind),
+            (15, ["xinner"], -1),
+            (16, [], -1),
+            (17, ["xouter"], -1),
             # outer divertor leg
-            {
-                "i": 18,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 19,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 20,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 21,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 22,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 23,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 24,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 25,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 26,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (18, ["xinner"], -1),
+            (19, [], -1),
+            (20, ["xouter"], -1),
+            (21, ["xinner"], -1),
+            (22, [], -1),
+            (23, ["xouter"], -1),
+            (24, ["xinner", "yupper"], -1),
+            (25, ["yupper"], -1),
+            (26, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -1507,50 +1173,28 @@ class TestCollect:
 
         dump_params = [
             # inner, lower divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "xouter", "ylower"], -1),
             # inner core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (1, ["xinner", "xouter"], fieldperp_global_yind),
             # inner, upper divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
             # outer, upper divertor leg
-            {
-                "i": 3,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (3, ["xinner", "xouter", "ylower"], -1),
             # outer core
-            {
-                "i": 4,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (4, ["xinner", "xouter"], -1),
             # outer, lower divertor leg
-            {
-                "i": 5,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (5, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -1586,290 +1230,76 @@ class TestCollect:
 
         dump_params = [
             # inner, lower divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], -1),
+            (1, ["ylower"], -1),
+            (2, ["xouter", "ylower"], -1),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner"], -1),
+            (7, [], -1),
+            (8, ["xouter"], -1),
             # inner core
-            {
-                "i": 9,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 10,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 11,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 12,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 13,
-                "boundaries": [],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 14,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 15,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 16,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 17,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (9, ["xinner"], -1),
+            (10, [], -1),
+            (11, ["xouter"], -1),
+            (12, ["xinner"], fieldperp_global_yind),
+            (13, [], fieldperp_global_yind),
+            (14, ["xouter"], fieldperp_global_yind),
+            (15, ["xinner"], -1),
+            (16, [], -1),
+            (17, ["xouter"], -1),
             # inner, upper divertor leg
-            {
-                "i": 18,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 19,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 20,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 21,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 22,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 23,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 24,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 25,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 26,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (18, ["xinner"], -1),
+            (19, [], -1),
+            (20, ["xouter"], -1),
+            (21, ["xinner"], -1),
+            (22, [], -1),
+            (23, ["xouter"], -1),
+            (24, ["xinner", "yupper"], -1),
+            (25, ["yupper"], -1),
+            (26, ["xouter", "yupper"], -1),
             # outer, upper divertor leg
-            {
-                "i": 27,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 28,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 29,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 30,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 31,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 32,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 33,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 34,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 35,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (27, ["xinner", "ylower"], -1),
+            (28, ["ylower"], -1),
+            (29, ["xouter", "ylower"], -1),
+            (30, ["xinner"], -1),
+            (31, [], -1),
+            (32, ["xouter"], -1),
+            (33, ["xinner"], -1),
+            (34, [], -1),
+            (35, ["xouter"], -1),
             # outer core
-            {
-                "i": 36,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 37,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 38,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 39,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 40,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 41,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 42,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 43,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 44,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (36, ["xinner"], -1),
+            (37, [], -1),
+            (38, ["xouter"], -1),
+            (39, ["xinner"], -1),
+            (40, [], -1),
+            (41, ["xouter"], -1),
+            (42, ["xinner"], -1),
+            (43, [], -1),
+            (44, ["xouter"], -1),
             # outer, lower divertor leg
-            {
-                "i": 45,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 46,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 47,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 48,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 49,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 50,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 51,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 52,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 53,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (45, ["xinner"], -1),
+            (46, [], -1),
+            (47, ["xouter"], -1),
+            (48, ["xinner"], -1),
+            (49, [], -1),
+            (50, ["xouter"], -1),
+            (51, ["xinner", "yupper"], -1),
+            (52, ["yupper"], -1),
+            (53, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -1902,50 +1332,28 @@ class TestCollect:
 
         dump_params = [
             # inner, lower divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "xouter", "ylower"], -1),
             # inner core
-            {
-                "i": 1,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
+            (1, ["xinner", "xouter"], fieldperp_global_yind),
             # inner, upper divertor leg
-            {
-                "i": 2,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (2, ["xinner", "xouter", "yupper"], -1),
             # outer, upper divertor leg
-            {
-                "i": 3,
-                "boundaries": ["xinner", "xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
+            (3, ["xinner", "xouter", "ylower"], -1),
             # outer core
-            {
-                "i": 4,
-                "boundaries": ["xinner", "xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (4, ["xinner", "xouter"], -1),
             # outer, lower divertor leg
-            {
-                "i": 5,
-                "boundaries": ["xinner", "xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (5, ["xinner", "xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -1983,290 +1391,76 @@ class TestCollect:
 
         dump_params = [
             # inner, lower divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], -1),
+            (1, ["ylower"], -1),
+            (2, ["xouter", "ylower"], -1),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner"], -1),
+            (7, [], -1),
+            (8, ["xouter"], -1),
             # inner core
-            {
-                "i": 9,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 10,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 11,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 12,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 13,
-                "boundaries": [],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 14,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 15,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 16,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 17,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (9, ["xinner"], -1),
+            (10, [], -1),
+            (11, ["xouter"], -1),
+            (12, ["xinner"], fieldperp_global_yind),
+            (13, [], fieldperp_global_yind),
+            (14, ["xouter"], fieldperp_global_yind),
+            (15, ["xinner"], -1),
+            (16, [], -1),
+            (17, ["xouter"], -1),
             # inner, upper divertor leg
-            {
-                "i": 18,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 19,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 20,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 21,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 22,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 23,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 24,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 25,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 26,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (18, ["xinner"], -1),
+            (19, [], -1),
+            (20, ["xouter"], -1),
+            (21, ["xinner"], -1),
+            (22, [], -1),
+            (23, ["xouter"], -1),
+            (24, ["xinner", "yupper"], -1),
+            (25, ["yupper"], -1),
+            (26, ["xouter", "yupper"], -1),
             # outer, upper divertor leg
-            {
-                "i": 27,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 28,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 29,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 30,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 31,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 32,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 33,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 34,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 35,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (27, ["xinner", "ylower"], -1),
+            (28, ["ylower"], -1),
+            (29, ["xouter", "ylower"], -1),
+            (30, ["xinner"], -1),
+            (31, [], -1),
+            (32, ["xouter"], -1),
+            (33, ["xinner"], -1),
+            (34, [], -1),
+            (35, ["xouter"], -1),
             # outer core
-            {
-                "i": 36,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 37,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 38,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 39,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 40,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 41,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 42,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 43,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 44,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (36, ["xinner"], -1),
+            (37, [], -1),
+            (38, ["xouter"], -1),
+            (39, ["xinner"], -1),
+            (40, [], -1),
+            (41, ["xouter"], -1),
+            (42, ["xinner"], -1),
+            (43, [], -1),
+            (44, ["xouter"], -1),
             # outer, lower divertor leg
-            {
-                "i": 45,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 46,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 47,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 48,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 49,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 50,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 51,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 52,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 53,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (45, ["xinner"], -1),
+            (46, [], -1),
+            (47, ["xouter"], -1),
+            (48, ["xinner"], -1),
+            (49, [], -1),
+            (50, ["xouter"], -1),
+            (51, ["xinner", "yupper"], -1),
+            (52, ["yupper"], -1),
+            (53, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 
@@ -2316,290 +1510,76 @@ class TestCollect:
 
         dump_params = [
             # inner, lower divertor leg
-            {
-                "i": 0,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 1,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 2,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 3,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 4,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 5,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 6,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 7,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 8,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (0, ["xinner", "ylower"], -1),
+            (1, ["ylower"], -1),
+            (2, ["xouter", "ylower"], -1),
+            (3, ["xinner"], -1),
+            (4, [], -1),
+            (5, ["xouter"], -1),
+            (6, ["xinner"], -1),
+            (7, [], -1),
+            (8, ["xouter"], -1),
             # inner core
-            {
-                "i": 9,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 10,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 11,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 12,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 13,
-                "boundaries": [],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 14,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": fieldperp_global_yind,
-            },
-            {
-                "i": 15,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 16,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 17,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (9, ["xinner"], -1),
+            (10, [], -1),
+            (11, ["xouter"], -1),
+            (12, ["xinner"], fieldperp_global_yind),
+            (13, [], fieldperp_global_yind),
+            (14, ["xouter"], fieldperp_global_yind),
+            (15, ["xinner"], -1),
+            (16, [], -1),
+            (17, ["xouter"], -1),
             # inner, upper divertor leg
-            {
-                "i": 18,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 19,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 20,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 21,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 22,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 23,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 24,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 25,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 26,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (18, ["xinner"], -1),
+            (19, [], -1),
+            (20, ["xouter"], -1),
+            (21, ["xinner"], -1),
+            (22, [], -1),
+            (23, ["xouter"], -1),
+            (24, ["xinner", "yupper"], -1),
+            (25, ["yupper"], -1),
+            (26, ["xouter", "yupper"], -1),
             # outer, upper divertor leg
-            {
-                "i": 27,
-                "boundaries": ["xinner", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 28,
-                "boundaries": ["ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 29,
-                "boundaries": ["xouter", "ylower"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 30,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 31,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 32,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 33,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 34,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 35,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (27, ["xinner", "ylower"], -1),
+            (28, ["ylower"], -1),
+            (29, ["xouter", "ylower"], -1),
+            (30, ["xinner"], -1),
+            (31, [], -1),
+            (32, ["xouter"], -1),
+            (33, ["xinner"], -1),
+            (34, [], -1),
+            (35, ["xouter"], -1),
             # outer core
-            {
-                "i": 36,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 37,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 38,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 39,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 40,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 41,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 42,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 43,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 44,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
+            (36, ["xinner"], -1),
+            (37, [], -1),
+            (38, ["xouter"], -1),
+            (39, ["xinner"], -1),
+            (40, [], -1),
+            (41, ["xouter"], -1),
+            (42, ["xinner"], -1),
+            (43, [], -1),
+            (44, ["xouter"], -1),
             # outer, lower divertor leg
-            {
-                "i": 45,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 46,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 47,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 48,
-                "boundaries": ["xinner"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 49,
-                "boundaries": [],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 50,
-                "boundaries": ["xouter"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 51,
-                "boundaries": ["xinner", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 52,
-                "boundaries": ["yupper"],
-                "fieldperp_global_yind": -1,
-            },
-            {
-                "i": 53,
-                "boundaries": ["xouter", "yupper"],
-                "fieldperp_global_yind": -1,
-            },
+            (45, ["xinner"], -1),
+            (46, [], -1),
+            (47, ["xouter"], -1),
+            (48, ["xinner"], -1),
+            (49, [], -1),
+            (50, ["xouter"], -1),
+            (51, ["xinner", "yupper"], -1),
+            (52, ["yupper"], -1),
+            (53, ["xouter", "yupper"], -1),
         ]
         dumps = []
-        for p in dump_params:
+        for i, boundaries, fieldperp_yind in dump_params:
             dumps.append(
                 create_dump_file(
                     tmpdir=tmp_path,
                     rng=rng,
                     grid_info=grid_info,
-                    **p,
+                    i=i,
+                    boundaries=boundaries,
+                    fieldperp_global_yind=fieldperp_yind,
                 )
             )
 

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -513,6 +513,160 @@ class TestCollect:
 
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
+    def test_singlenull_min_files_lower_boundary_fieldperp(
+        self, tmp_path, squash, collect_kwargs
+    ):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 1
+        fieldperp_yproc_ind = 0
+
+        rng = np.random.default_rng(104)
+
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            # core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            doublenull=False,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
+    def test_singlenull_min_files_upper_boundary_fieldperp(
+        self, tmp_path, squash, collect_kwargs
+    ):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 14
+        fieldperp_yproc_ind = 2
+
+        rng = np.random.default_rng(104)
+
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            doublenull=False,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull(self, tmp_path, squash, collect_kwargs):
         grid_info = {}
         grid_info["iteration"] = 6

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -1,0 +1,489 @@
+from glob import glob
+import numpy as np
+import numpy.testing as npt
+from pathlib import Path
+import pytest
+
+from boutdata.collect import collect
+from boutdata.squashoutput import squashoutput
+
+from boutdata.tests.make_test_data import (
+    create_dump_file,
+    concatenate_data,
+    expected_attributes,
+)
+
+# Note - using tmp_path fixture requires pytest>=3.9.0
+
+squash_kwargs = [
+    {},
+    {"compress": True},
+    {"compress": True, "complevel": 0},
+    {"compress": True, "complevel": 1},
+    {"compress": True, "complevel": 2},
+    {"compress": True, "complevel": 3},
+    {"compress": True, "complevel": 4},
+    {"compress": True, "complevel": 5},
+    {"compress": True, "complevel": 6},
+    {"compress": True, "complevel": 7},
+    {"compress": True, "complevel": 8},
+    {"compress": True, "complevel": 9},
+]
+
+
+def check_collected_data(
+    expected, *, fieldperp_global_yind, path, squash, collect_kwargs, squash_kwargs
+):
+    if squash:
+        squashoutput(path, outputname="boutdata.nc", **collect_kwargs)
+        collect_kwargs["prefix"] = "boutdata"
+        # Delete dump files to be sure we do not read from them
+        dump_names = glob(str(path.joinpath("BOUT.dmp.*.nc")))
+        for x in dump_names:
+            Path(x).unlink()
+        # Reset arguments that are taken care of by squashoutput
+        for x in ("tind", "xind", "yind", "zind"):
+            if x in collect_kwargs:
+                collect_kwargs.pop(x)
+
+    for varname in expected:
+        actual = collect(varname, path=path, **collect_kwargs)
+        npt.assert_array_equal(expected[varname], actual)
+        actual_keys = list(actual.attributes.keys())
+        if varname in expected_attributes:
+            for a in expected_attributes[varname]:
+                assert actual.attributes[a] == expected_attributes[varname][a]
+                actual_keys.remove(a)
+
+        if "fieldperp" in varname:
+            assert actual.attributes["yindex_global"] == fieldperp_global_yind
+            actual_keys.remove("yindex_global")
+
+        assert actual_keys == ["bout_type"]
+
+        if "field3d_t" in varname:
+            assert actual.attributes["bout_type"] == "Field3D_t"
+        elif "field3d" in varname:
+            assert actual.attributes["bout_type"] == "Field3D"
+        elif "field2d_t" in varname:
+            assert actual.attributes["bout_type"] == "Field2D_t"
+        elif "field2d" in varname:
+            assert actual.attributes["bout_type"] == "Field2D"
+        elif "fieldperp_t" in varname:
+            assert actual.attributes["bout_type"] == "FieldPerp_t"
+        elif "fieldperp" in varname:
+            assert actual.attributes["bout_type"] == "FieldPerp"
+        elif "_t" in varname or varname == "t_array":
+            assert actual.attributes["bout_type"] == "scalar_t"
+        else:
+            assert actual.attributes["bout_type"] == "scalar"
+
+
+class TestCollect:
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_singlenull_min_files(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 7
+        fieldperp_yproc_ind = 1
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # inner divertor leg
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # core
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+
+        # outer divertor leg
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_singlenull(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 9
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 7
+        grid_info["ixseps2"] = 13
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 6 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # inner divertor leg
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "ylower"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=3,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=4,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=5,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=6,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=7,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=8,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # core
+        dumps.append(
+            create_dump_file(
+                i=9,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=10,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=11,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=12,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=13,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=14,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=15,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=16,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=17,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        # outer divertor leg
+        dumps.append(
+            create_dump_file(
+                i=18,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=19,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=20,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=21,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=22,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=23,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=24,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=25,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=26,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -176,6 +176,208 @@ class TestCollect:
         dumps = []
 
         # core
+        # core includes "ylower" and "yupper" even though there is no actual y-boundary
+        # because collect/squashoutput collect these points
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=3,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=4,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=5,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=6,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=7,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=8,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_sol_min_files(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 1
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 0
+        grid_info["ixseps2"] = 0
+        grid_info["jyseps1_1"] = -1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+
+        fieldperp_global_yind = 3
+        fieldperp_yproc_ind = 0
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # SOL
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "ylower", "yupper"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_sol(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 0
+        grid_info["ixseps2"] = 0
+        grid_info["jyseps1_1"] = -1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+
+        fieldperp_global_yind = 3
+        fieldperp_yproc_ind = 0
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # SOL
         dumps.append(
             create_dump_file(
                 i=0,

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -15,15 +15,8 @@ from boutdata.tests.make_test_data import (
 
 # Note - using tmp_path fixture requires pytest>=3.9.0
 
-squash_kwargs = [
-    {},
-    {"compress": True, "complevel": 1},
-    {"compress": True, "complevel": 9},
-]
-
-
 def check_collected_data(
-    expected, *, fieldperp_global_yind, path, squash, collect_kwargs, squash_kwargs
+    expected, *, fieldperp_global_yind, path, squash, collect_kwargs, squash_kwargs={}
 ):
     if squash:
         squashoutput(path, outputname="boutdata.nc", **collect_kwargs)
@@ -72,8 +65,7 @@ def check_collected_data(
 
 class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_core_min_files(self, tmp_path, squash, squash_kwargs):
+    def test_core_min_files(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -135,12 +127,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_core(self, tmp_path, squash, squash_kwargs):
+    def test_core(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -242,12 +232,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_sol_min_files(self, tmp_path, squash, squash_kwargs):
+    def test_sol_min_files(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -307,12 +295,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_sol(self, tmp_path, squash, squash_kwargs):
+    def test_sol(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -412,12 +398,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_singlenull_min_files(self, tmp_path, squash, squash_kwargs):
+    def test_singlenull_min_files(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -489,12 +473,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_singlenull(self, tmp_path, squash, squash_kwargs):
+    def test_singlenull(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -686,12 +668,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_connected_doublenull_min_files(self, tmp_path, squash, squash_kwargs):
+    def test_connected_doublenull_min_files(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -781,12 +761,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_connected_doublenull(self, tmp_path, squash, squash_kwargs):
+    def test_connected_doublenull(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -1116,12 +1094,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_disconnected_doublenull_min_files(self, tmp_path, squash, squash_kwargs):
+    def test_disconnected_doublenull_min_files(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -1211,12 +1187,10 @@ class TestCollect:
             path=tmp_path,
             squash=squash,
             collect_kwargs=collect_kwargs,
-            squash_kwargs=squash_kwargs,
         )
 
     @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
-    def test_disconnected_doublenull(self, tmp_path, squash, squash_kwargs):
+    def test_disconnected_doublenull(self, tmp_path, squash):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
@@ -1545,6 +1519,346 @@ class TestCollect:
             fieldperp_global_yind=fieldperp_global_yind,
             path=tmp_path,
             squash=squash,
+            collect_kwargs=collect_kwargs,
+        )
+
+    @pytest.mark.parametrize(
+        "squash_kwargs",
+        [
+            {},
+            {"compress": True, "complevel": 1},
+            {"compress": True, "complevel": 9},
+        ],
+    )
+    def test_disconnected_doublenull_with_compression(self, tmp_path, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 18
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 6
+        grid_info["ixseps2"] = 11
+        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(109)
+
+        dump_params = [
+            # inner, lower divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner core
+            {
+                "i": 9,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 10,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 11,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 12,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 13,
+                "boundaries": [],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 14,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 15,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 16,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 17,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner, upper divertor leg
+            {
+                "i": 18,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 19,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 20,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 21,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 22,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 23,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 24,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 25,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 26,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, upper divertor leg
+            {
+                "i": 27,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 28,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 29,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 30,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 31,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 32,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 33,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 34,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 35,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer core
+            {
+                "i": 36,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 37,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 38,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 39,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 40,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 41,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 42,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 43,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 44,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, lower divertor leg
+            {
+                "i": 45,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 46,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 47,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 48,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 49,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 50,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 51,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 52,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 53,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=True,
             collect_kwargs=collect_kwargs,
             squash_kwargs=squash_kwargs,
         )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -1939,14 +1939,16 @@ class TestCollect:
 
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
-    def test_disconnected_doublenull(self, tmp_path, squash, collect_kwargs):
+    @pytest.mark.parametrize("mxg", [0, 1, 2])
+    @pytest.mark.parametrize("myg", [0, 1, 2])
+    def test_disconnected_doublenull(self, tmp_path, squash, collect_kwargs, mxg, myg):
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
         grid_info["MYSUB"] = 4
         grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
+        grid_info["MXG"] = mxg
+        grid_info["MYG"] = myg
         grid_info["MZG"] = 0
         grid_info["NXPE"] = 3
         grid_info["NYPE"] = 18

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -2288,6 +2288,13 @@ class TestCollect:
         [
             {},
             {"compress": True, "complevel": 1},
+            {"compress": True, "complevel": 2},
+            {"compress": True, "complevel": 3},
+            {"compress": True, "complevel": 4},
+            {"compress": True, "complevel": 5},
+            {"compress": True, "complevel": 5},
+            {"compress": True, "complevel": 7},
+            {"compress": True, "complevel": 8},
             {"compress": True, "complevel": 9},
         ],
     )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -201,6 +201,9 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_core_min_files(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a core-only case using the minimum number of processes
+        """
         grid_info = self.make_grid_info()
 
         fieldperp_global_yind = 3
@@ -245,6 +248,11 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_core(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a core-only case using a large number of processes. 'Large'
+        means there is at least one process in each region with no edges touching
+        another region.
+        """
         grid_info = self.make_grid_info(nxpe=3, nype=3)
 
         fieldperp_global_yind = 3
@@ -329,6 +337,9 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_sol_min_files(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a SOL-only case using the minimum number of processes
+        """
         grid_info = self.make_grid_info(ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
@@ -371,6 +382,11 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_sol(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a SOL-only case using a large number of processes. 'Large'
+        means there is at least one process in each region with no edges touching
+        another region.
+        """
         grid_info = self.make_grid_info(nxpe=3, nype=3, ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
@@ -453,6 +469,9 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull_min_files(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a single-null case using the minimum number of processes
+        """
         grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
@@ -509,6 +528,10 @@ class TestCollect:
     def test_singlenull_min_files_lower_boundary_fieldperp(
         self, tmp_path, squash, collect_kwargs
     ):
+        """
+        Check output from a single-null case using the minimum number of processes. This
+        test puts the FieldPerp in the lower boundary.
+        """
         grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 1
@@ -565,6 +588,10 @@ class TestCollect:
     def test_singlenull_min_files_upper_boundary_fieldperp(
         self, tmp_path, squash, collect_kwargs
     ):
+        """
+        Check output from a single-null case using the minimum number of processes. This
+        test puts the FieldPerp in the upper boundary.
+        """
         grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 14
@@ -620,6 +647,11 @@ class TestCollect:
     def test_singlenull_min_files_fieldperp_on_two_yproc_different_index(
         self, tmp_path, squash
     ):
+        """
+        Check output from a single-null case using the minimum number of processes. This
+        test has FieldPerps created with inconsistent y-indices to check this produces
+        an error.
+        """
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
         grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
@@ -678,6 +710,11 @@ class TestCollect:
     def test_singlenull_min_files_fieldperp_on_two_yproc_same_index(
         self, tmp_path, squash
     ):
+        """
+        Check output from a single-null case using the minimum number of processes. This
+        test has FieldPerps created on different y-processes to check this produces an
+        error.
+        """
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
         grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
@@ -735,6 +772,11 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a single-null case using a large number of processes. 'Large'
+        means there is at least one process in each region with no edges touching
+        another region.
+        """
         grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
@@ -1253,6 +1295,12 @@ class TestCollect:
     def test_singlenull_tind_xind_yind_zind(
         self, tmp_path, squash, tind, xind, yind, zind
     ):
+        """
+        Check output from a single-null case using a large number of processes. 'Large'
+        means there is at least one process in each region with no edges touching
+        another region. This test checks the 'tind', 'xind', 'yind' and 'zind' arguments
+        to `collect()` and `squashoutput()`.
+        """
         tind, tslice = tind
         xind, xslice = xind
         yind, yslice = yind
@@ -1446,6 +1494,10 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_connected_doublenull_min_files(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a connected double-null case using the minimum number of
+        processes
+        """
         grid_info = self.make_grid_info(nype=6, ixseps1=4, ixseps2=4, xpoints=2)
 
         fieldperp_global_yind = 7
@@ -1518,6 +1570,11 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_connected_doublenull(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a connected double-null case using a large number of
+        processes. 'Large' means there is at least one process in each region with no
+        edges touching another region.
+        """
         grid_info = self.make_grid_info(
             nxpe=3, nype=18, ixseps1=7, ixseps2=7, xpoints=2
         )
@@ -1832,6 +1889,10 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_disconnected_doublenull_min_files(self, tmp_path, squash, collect_kwargs):
+        """
+        Check output from a disconnected double-null case using the minimum number of
+        processes
+        """
         grid_info = self.make_grid_info(nype=6, ixseps1=3, ixseps2=5, xpoints=2)
 
         fieldperp_global_yind = 7
@@ -1906,6 +1967,11 @@ class TestCollect:
     @pytest.mark.parametrize("mxg", [0, 1, 2])
     @pytest.mark.parametrize("myg", [0, 1, 2])
     def test_disconnected_doublenull(self, tmp_path, squash, collect_kwargs, mxg, myg):
+        """
+        Check output from a disconnected double-null case using a large number of
+        processes. 'Large' means there is at least one process in each region with no
+        edges touching another region.
+        """
         grid_info = self.make_grid_info(
             mxg=mxg, myg=myg, nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
         )
@@ -2226,6 +2292,12 @@ class TestCollect:
         ],
     )
     def test_disconnected_doublenull_with_compression(self, tmp_path, squash_kwargs):
+        """
+        Check output from a disconnected double-null case using a large number of
+        processes. 'Large' means there is at least one process in each region with no
+        edges touching another region. This test checks some compression options that
+        can be used with `squashoutput()`, verifying that they do not modify data.
+        """
         grid_info = self.make_grid_info(
             nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
         )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -167,7 +167,7 @@ class TestCollect:
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(101)
 
         # core
         # core includes "ylower" and "yupper" even though there is no actual y-boundary
@@ -274,7 +274,7 @@ class TestCollect:
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(102)
 
         # SOL
         dump_params = [
@@ -339,7 +339,7 @@ class TestCollect:
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(103)
 
         # SOL
         dump_params = [
@@ -444,7 +444,7 @@ class TestCollect:
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(104)
 
         dump_params = [
             # inner divertor leg
@@ -521,7 +521,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(105)
 
         dump_params = [
             # inner divertor leg
@@ -718,7 +718,7 @@ class TestCollect:
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(106)
 
         dump_params = [
             # inner, lower divertor leg
@@ -813,7 +813,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(107)
 
         dump_params = [
             # inner, lower divertor leg
@@ -1148,7 +1148,7 @@ class TestCollect:
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(108)
 
         dump_params = [
             # inner, lower divertor leg
@@ -1243,7 +1243,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(100)
+        rng = np.random.default_rng(109)
 
         dump_params = [
             # inner, lower divertor leg

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -1118,3 +1118,433 @@ class TestCollect:
             collect_kwargs=collect_kwargs,
             squash_kwargs=squash_kwargs,
         )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_disconnected_doublenull_min_files(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 6
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 3
+        grid_info["ixseps2"] = 5
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 2 * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 3 * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 4 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 5 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 7
+        fieldperp_yproc_ind = 1
+
+        rng = np.random.default_rng(100)
+
+        dump_params = [
+            # inner, lower divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            # inner, upper divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, upper divertor leg
+            {
+                "i": 3,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer core
+            {
+                "i": 4,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, lower divertor leg
+            {
+                "i": 5,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_disconnected_doublenull(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 18
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 6
+        grid_info["ixseps2"] = 11
+        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(100)
+
+        dump_params = [
+            # inner, lower divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner core
+            {
+                "i": 9,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 10,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 11,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 12,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 13,
+                "boundaries": [],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 14,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 15,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 16,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 17,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner, upper divertor leg
+            {
+                "i": 18,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 19,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 20,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 21,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 22,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 23,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 24,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 25,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 26,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, upper divertor leg
+            {
+                "i": 27,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 28,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 29,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 30,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 31,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 32,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 33,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 34,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 35,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer core
+            {
+                "i": 36,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 37,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 38,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 39,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 40,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 41,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 42,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 43,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 44,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, lower divertor leg
+            {
+                "i": 45,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 46,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 47,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 48,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 49,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 50,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 51,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 52,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 53,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -39,6 +39,27 @@ def check_collected_data(
     collect_kwargs,
     squash_kwargs={},
 ):
+    """
+    Use `collect()` to read 'actual' data from the files. Test that 'actual' and
+    'expected' data and attributes match.
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    fieldperp_global_yind : int
+        Global y-index where FieldPerps are expected to be defined.
+    path : pathlib.Path or str
+        Path to collect data from.
+    squash : bool
+        If True, call `squashoutput()` and delete the `BOUT.dmp.*.nc` files (so that we
+        can only read the 'squashed' data) before collecting and checking data.
+    collect_kwargs : dict
+        Keyword arguments passed to `collect()`.
+    squash_kwargs : dict, optional
+        Keyword arguments passed to `squashoutput()`.
+    """
     # Apply effect of arguments to expected data
     if not collect_kwargs["xguards"]:
         remove_xboundaries(expected, expected["MXG"])

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -17,16 +17,7 @@ from boutdata.tests.make_test_data import (
 
 squash_kwargs = [
     {},
-    {"compress": True},
-    {"compress": True, "complevel": 0},
     {"compress": True, "complevel": 1},
-    {"compress": True, "complevel": 2},
-    {"compress": True, "complevel": 3},
-    {"compress": True, "complevel": 4},
-    {"compress": True, "complevel": 5},
-    {"compress": True, "complevel": 6},
-    {"compress": True, "complevel": 7},
-    {"compress": True, "complevel": 8},
     {"compress": True, "complevel": 9},
 ]
 

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -8,6 +8,7 @@ from boutdata.collect import collect
 from boutdata.squashoutput import squashoutput
 
 from boutdata.tests.make_test_data import (
+    apply_slices,
     create_dump_file,
     concatenate_data,
     expected_attributes,
@@ -706,6 +707,564 @@ class TestCollect:
         )
 
     @pytest.mark.parametrize("squash", [False, True])
+    # This parametrize passes tuples for 'tind', 'xind', 'yind' and 'zind'. The first
+    # value is the 'tind'/'xind'/'yind'/'zind' argument to pass to collect() or
+    # squashoutput(), the second is the equivalent slice() to use on the expected
+    # output.
+    #
+    # Note that the 3-element list form of the argument is inconsistent with the
+    # 2-element form as the 3-element uses an exclusive end index (like slice()) while
+    # the 2-element uses an inclusive end index (for backward compatibility).
+    @pytest.mark.parametrize(
+        ("tind", "xind", "yind", "zind"),
+        [
+            # t-slicing
+            (
+                (2, slice(2, 3)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (slice(4), slice(4)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                ([0, 3], slice(4)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (slice(2, None), slice(2, None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                ([2, -1], slice(2, None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (slice(2, 4), slice(2, 4)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                ([2, 3], slice(2, 4)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (slice(None, None, 3), slice(None, None, 3)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                ([0, -1, 3], slice(None, -1, 3)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (slice(1, 5, 2), slice(1, 5, 2)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                ([1, 4, 2], slice(1, 4, 2)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            # x-slicing
+            (
+                (None, slice(None)),
+                (7, slice(7, 8)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (slice(8), slice(8)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                ([0, 8], slice(9)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (slice(4, None), slice(4, None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                ([5, -1], slice(5, None)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (slice(6, 10), slice(6, 10)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                ([4, 8], slice(4, 9)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (slice(None, None, 4), slice(None, None, 4)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                ([0, -1, 3], slice(None, -1, 3)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (slice(3, 10, 3), slice(3, 10, 3)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                ([4, 8, 4], slice(4, 8, 4)),
+                (None, slice(None)),
+                (None, slice(None)),
+            ),
+            # y-slicing
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (17, slice(17, 18)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(30), slice(30)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                ([0, 28], slice(29)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(5, None), slice(5, None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                ([6, -1], slice(6, None)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(7, 28), slice(7, 28)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                ([8, 27], slice(8, 28)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(None, None, 5), slice(None, None, 5)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                ([0, -1, 6], slice(None, -1, 6)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(9, 26, 7), slice(9, 26, 7)),
+                (None, slice(None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                ([5, 33, 4], slice(5, 33, 4)),
+                (None, slice(None)),
+            ),
+            # z-slicing
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (1, slice(1, 2)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(3), slice(3)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                ([0, 2], slice(3)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(1, None), slice(1, None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                ([1, -1], slice(1, None)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(1, 3), slice(1, 3)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                ([1, 2], slice(1, 3)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(None, None, 2), slice(None, None, 2)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                ([0, -1, 2], slice(None, -1, 2)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                (slice(1, 4, 2), slice(1, 4, 2)),
+            ),
+            (
+                (None, slice(None)),
+                (None, slice(None)),
+                (None, slice(None)),
+                ([1, 3, 2], slice(1, 3, 2)),
+            ),
+            # combined slicing
+            ((2, slice(2, 3)), (7, slice(7, 8)), (17, slice(17, 18)), (1, slice(1, 2))),
+            (
+                (slice(4), slice(4)),
+                (slice(8), slice(8)),
+                (slice(30), slice(30)),
+                (slice(3), slice(3)),
+            ),
+            (
+                ([0, 3], slice(4)),
+                ([0, 9], slice(10)),
+                ([0, 28], slice(29)),
+                ([0, 2], slice(3)),
+            ),
+            (
+                (slice(2, None), slice(2, None)),
+                (slice(4, None), slice(4, None)),
+                (slice(5, None), slice(5, None)),
+                (slice(1, None), slice(1, None)),
+            ),
+            (
+                ([2, -1], slice(2, None)),
+                ([5, -1], slice(5, None)),
+                ([6, -1], slice(6, None)),
+                ([1, -1], slice(1, None)),
+            ),
+            (
+                (slice(2, 4), slice(2, 4)),
+                (slice(6, 10), slice(6, 10)),
+                (slice(7, 28), slice(7, 28)),
+                (slice(1, 3), slice(1, 3)),
+            ),
+            (
+                ([2, 3], slice(2, 4)),
+                ([4, 8], slice(4, 9)),
+                ([8, 27], slice(8, 28)),
+                ([1, 2], slice(1, 3)),
+            ),
+            (
+                (slice(None, None, 3), slice(None, None, 3)),
+                (slice(None, None, 4), slice(None, None, 4)),
+                (slice(None, None, 5), slice(None, None, 5)),
+                (slice(None, None, 2), slice(None, None, 2)),
+            ),
+            (
+                ([0, -1, 3], slice(None, -1, 3)),
+                ([0, -1, 3], slice(None, -1, 3)),
+                ([0, -1, 6], slice(None, -1, 6)),
+                ([0, -1, 2], slice(None, -1, 2)),
+            ),
+            (
+                (slice(1, 5, 2), slice(1, 5, 2)),
+                (slice(3, 10, 3), slice(3, 10, 3)),
+                (slice(9, 26, 7), slice(9, 26, 7)),
+                (slice(1, 4, 2), slice(1, 4, 2)),
+            ),
+            (
+                ([1, 4, 2], slice(1, 4, 2)),
+                ([4, 8, 4], slice(4, 8, 4)),
+                ([5, 33, 4], slice(5, 33, 4)),
+                ([1, 3, 2], slice(1, 3, 2)),
+            ),
+        ],
+    )
+    def test_singlenull_tind_xind_yind_zind(
+        self, tmp_path, squash, tind, xind, yind, zind
+    ):
+        tind, tslice = tind
+        xind, xslice = xind
+        yind, yslice = yind
+        zind, zslice = zind
+
+        collect_kwargs = {
+            "xguards": True,
+            "yguards": "include_upper",
+            "tind": tind,
+            "xind": xind,
+            "yind": yind,
+            "zind": zind,
+        }
+
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 9
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 7
+        grid_info["ixseps2"] = 13
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 6 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(106)
+
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # core
+            {
+                "i": 9,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 10,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 11,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 12,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 13,
+                "boundaries": [],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 14,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 15,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 16,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 17,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer divertor leg
+            {
+                "i": 18,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 19,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 20,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 21,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 22,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 23,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 24,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 25,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 26,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        # Can only apply here (before effect of 'xguards' and 'yguards' is applied in
+        # check_collected_data) because we keep 'xguards=True' and
+        # 'yguards="include_upper"' for this test, so neither has an effect.
+        apply_slices(expected, tslice, xslice, yslice, zslice)
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            doublenull=False,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_connected_doublenull_min_files(self, tmp_path, squash, collect_kwargs):
         grid_info = {}
@@ -734,7 +1293,7 @@ class TestCollect:
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
 
-        rng = np.random.default_rng(106)
+        rng = np.random.default_rng(107)
 
         dump_params = [
             # inner, lower divertor leg
@@ -827,7 +1386,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(107)
+        rng = np.random.default_rng(108)
 
         dump_params = [
             # inner, lower divertor leg
@@ -1160,7 +1719,7 @@ class TestCollect:
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
 
-        rng = np.random.default_rng(108)
+        rng = np.random.default_rng(109)
 
         dump_params = [
             # inner, lower divertor leg
@@ -1253,7 +1812,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(109)
+        rng = np.random.default_rng(110)
 
         dump_params = [
             # inner, lower divertor leg
@@ -1592,7 +2151,7 @@ class TestCollect:
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
 
-        rng = np.random.default_rng(109)
+        rng = np.random.default_rng(111)
 
         dump_params = [
             # inner, lower divertor leg

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -121,31 +121,87 @@ def check_collected_data(
 
 
 class TestCollect:
-    @pytest.mark.parametrize("squash", [False, True])
-    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
-    def test_core_min_files(self, tmp_path, squash, collect_kwargs):
+    def make_grid_info(
+        self, *, mxg=2, myg=2, nxpe=1, nype=1, ixseps1=None, ixseps2=None, xpoints=0
+    ):
+        """
+        Create a dict of parameters used for creating test data
+
+        Parameters
+        ----------
+        mxg : int, optional
+            Number of guard cells in the x-direction
+        myg : int, optional
+            Number of guard cells in the y-direction
+        nxpe : int, optional
+            Number of processes in the x-direction
+        nype : int, optional
+            Number of processes in the y-direction
+        ixseps1 : int, optional
+            x-index (where indexing includes boundary points) of point just outside
+            first separatrix
+        ixseps2 : int, optional
+            x-index (where indexing includes boundary points) of point just outside
+            second separatrix
+        xpoints : int, optional
+            Number of X-points.
+        """
         grid_info = {}
         grid_info["iteration"] = 6
         grid_info["MXSUB"] = 3
         grid_info["MYSUB"] = 4
         grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
+        grid_info["MXG"] = mxg
+        grid_info["MYG"] = myg
         grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 1
+        grid_info["NXPE"] = nxpe
+        grid_info["NYPE"] = nype
         grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nx"] = nxpe * grid_info["MXSUB"] + 2 * mxg
+        grid_info["ny"] = nype * grid_info["MYSUB"]
         grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
         grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 7
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = -1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+        if ixseps1 is None:
+            grid_info["ixseps1"] = grid_info["nx"]
+        else:
+            grid_info["ixseps1"] = ixseps1
+        if ixseps2 is None:
+            grid_info["ixseps2"] = grid_info["nx"]
+        else:
+            grid_info["ixseps2"] = ixseps2
+        if xpoints == 0:
+            grid_info["jyseps1_1"] = -1
+            grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+            grid_info["ny_inner"] = grid_info["ny"] // 2
+            grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+            grid_info["jyseps2_2"] = grid_info["ny"]
+        elif xpoints == 1:
+            if nype < 3:
+                raise ValueError(f"nype={nype} not enough for single-null")
+            yproc_per_region = nype // 3
+            grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
+            grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+            grid_info["ny_inner"] = grid_info["ny"] // 2
+            grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+            grid_info["jyseps2_2"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
+        elif xpoints == 2:
+            if nype < 6:
+                raise ValueError(f"nype={nype} not enough for single-null")
+            yproc_per_region = nype // 6
+            grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
+            grid_info["jyseps2_1"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
+            grid_info["ny_inner"] = 3 * yproc_per_region * grid_info["MYSUB"]
+            grid_info["jyseps1_2"] = 4 * yproc_per_region * grid_info["MYSUB"] - 1
+            grid_info["jyseps2_2"] = 5 * yproc_per_region * grid_info["MYSUB"] - 1
+        else:
+            raise ValueError(f"Unsupported value for xpoints: {xpoints}")
+
+        return grid_info
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
+    def test_core_min_files(self, tmp_path, squash, collect_kwargs):
+        grid_info = self.make_grid_info()
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -189,28 +245,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_core(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 7
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = -1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+        grid_info = self.make_grid_info(nxpe=3, nype=3)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -294,28 +329,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_sol_min_files(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 1
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 0
-        grid_info["ixseps2"] = 0
-        grid_info["jyseps1_1"] = -1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+        grid_info = self.make_grid_info(ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -357,28 +371,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_sol(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 0
-        grid_info["ixseps2"] = 0
-        grid_info["jyseps1_1"] = -1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+        grid_info = self.make_grid_info(nxpe=3, nype=3, ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -460,28 +453,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull_min_files(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -537,28 +509,7 @@ class TestCollect:
     def test_singlenull_min_files_lower_boundary_fieldperp(
         self, tmp_path, squash, collect_kwargs
     ):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 1
         fieldperp_yproc_ind = 0
@@ -614,28 +565,7 @@ class TestCollect:
     def test_singlenull_min_files_upper_boundary_fieldperp(
         self, tmp_path, squash, collect_kwargs
     ):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 14
         fieldperp_yproc_ind = 2
@@ -692,28 +622,7 @@ class TestCollect:
     ):
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -771,28 +680,7 @@ class TestCollect:
     ):
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 3
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -847,28 +735,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 9
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 7
-        grid_info["ixseps2"] = 13
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 6 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -1400,28 +1267,7 @@ class TestCollect:
             "zind": zind,
         }
 
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 9
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 7
-        grid_info["ixseps2"] = 13
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-        grid_info["ny_inner"] = grid_info["ny"] // 2
-        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-        grid_info["jyseps2_2"] = 6 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -1600,28 +1446,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_connected_doublenull_min_files(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 6
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 4
-        grid_info["ixseps2"] = 4
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = 2 * grid_info["MYSUB"] - 1
-        grid_info["ny_inner"] = 3 * grid_info["MYSUB"]
-        grid_info["jyseps1_2"] = 4 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_2"] = 5 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=6, ixseps1=4, ixseps2=4, xpoints=2)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -1693,28 +1518,9 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_connected_doublenull(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 18
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 7
-        grid_info["ixseps2"] = 7
-        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
-        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
-        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(
+            nxpe=3, nype=18, ixseps1=7, ixseps2=7, xpoints=2
+        )
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -2026,28 +1832,7 @@ class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_disconnected_doublenull_min_files(self, tmp_path, squash, collect_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 1
-        grid_info["NYPE"] = 6
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 3
-        grid_info["ixseps2"] = 5
-        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = 2 * grid_info["MYSUB"] - 1
-        grid_info["ny_inner"] = 3 * grid_info["MYSUB"]
-        grid_info["jyseps1_2"] = 4 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_2"] = 5 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(nype=6, ixseps1=3, ixseps2=5, xpoints=2)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -2121,28 +1906,9 @@ class TestCollect:
     @pytest.mark.parametrize("mxg", [0, 1, 2])
     @pytest.mark.parametrize("myg", [0, 1, 2])
     def test_disconnected_doublenull(self, tmp_path, squash, collect_kwargs, mxg, myg):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = mxg
-        grid_info["MYG"] = myg
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 18
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 6
-        grid_info["ixseps2"] = 11
-        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
-        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
-        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(
+            mxg=mxg, myg=myg, nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
+        )
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -2460,28 +2226,9 @@ class TestCollect:
         ],
     )
     def test_disconnected_doublenull_with_compression(self, tmp_path, squash_kwargs):
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = 2
-        grid_info["MYG"] = 2
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = 3
-        grid_info["NYPE"] = 18
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
-        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        grid_info["ixseps1"] = 6
-        grid_info["ixseps2"] = 11
-        grid_info["jyseps1_1"] = 3 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_1"] = 6 * grid_info["MYSUB"] - 1
-        grid_info["ny_inner"] = 9 * grid_info["MYSUB"]
-        grid_info["jyseps1_2"] = 12 * grid_info["MYSUB"] - 1
-        grid_info["jyseps2_2"] = 15 * grid_info["MYSUB"] - 1
+        grid_info = self.make_grid_info(
+            nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
+        )
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -102,21 +102,26 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
-        dumps = []
-
         # core
         # core includes "ylower" and "yupper" even though there is no actual y-boundary
         # because collect/squashoutput collect these points
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "ylower", "yupper"],
-                fieldperp_global_yind=fieldperp_global_yind,
+        dump_params = [
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower", "yupper"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -164,101 +169,66 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
-        dumps = []
-
         # core
         # core includes "ylower" and "yupper" even though there is no actual y-boundary
         # because collect/squashoutput collect these points
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
+        dump_params = [
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=3,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=4,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=5,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=6,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=7,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=8,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -306,19 +276,24 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
-        dumps = []
-
         # SOL
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "ylower", "yupper"],
-                fieldperp_global_yind=fieldperp_global_yind,
+        dump_params = [
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower", "yupper"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -366,99 +341,64 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
-        dumps = []
-
         # SOL
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
+        dump_params = [
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "ylower"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=3,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=4,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=5,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=6,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=7,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=8,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -506,43 +446,36 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            # outer divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
         dumps = []
-
-        # inner divertor leg
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "ylower"],
-                fieldperp_global_yind=-1,
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-
-        # core
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-
-        # outer divertor leg
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -590,283 +523,156 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # core
+            {
+                "i": 9,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 10,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 11,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 12,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 13,
+                "boundaries": [],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 14,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 15,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 16,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 17,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer divertor leg
+            {
+                "i": 18,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 19,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 20,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 21,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 22,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 23,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 24,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 25,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 26,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
         dumps = []
-
-        # inner divertor leg
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "ylower"],
-                fieldperp_global_yind=-1,
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=3,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=4,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=5,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=6,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=7,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=8,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # core
-        dumps.append(
-            create_dump_file(
-                i=9,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=10,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=11,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=12,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=13,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=14,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=15,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=16,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=17,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer divertor leg
-        dumps.append(
-            create_dump_file(
-                i=18,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=19,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=20,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=21,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=22,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=23,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=24,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=25,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=26,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -914,79 +720,54 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
+        dump_params = [
+            # inner, lower divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            # inner, upper divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, upper divertor leg
+            {
+                "i": 3,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer core
+            {
+                "i": 4,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, lower divertor leg
+            {
+                "i": 5,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
         dumps = []
-
-        # inner, lower divertor leg
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "ylower"],
-                fieldperp_global_yind=-1,
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-
-        # inner core
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-
-        # inner, upper divertor leg
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer, upper divertor leg
-        dumps.append(
-            create_dump_file(
-                i=3,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer core
-        dumps.append(
-            create_dump_file(
-                i=4,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer, lower divertor leg
-        dumps.append(
-            create_dump_file(
-                i=5,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
@@ -1034,559 +815,294 @@ class TestCollect:
 
         rng = np.random.default_rng(100)
 
+        dump_params = [
+            # inner, lower divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 1,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 2,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 3,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 4,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 5,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 6,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 7,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 8,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner core
+            {
+                "i": 9,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 10,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 11,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 12,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 13,
+                "boundaries": [],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 14,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": fieldperp_global_yind,
+            },
+            {
+                "i": 15,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 16,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 17,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # inner, upper divertor leg
+            {
+                "i": 18,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 19,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 20,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 21,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 22,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 23,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 24,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 25,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 26,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, upper divertor leg
+            {
+                "i": 27,
+                "boundaries": ["xinner", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 28,
+                "boundaries": ["ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 29,
+                "boundaries": ["xouter", "ylower"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 30,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 31,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 32,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 33,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 34,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 35,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer core
+            {
+                "i": 36,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 37,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 38,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 39,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 40,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 41,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 42,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 43,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 44,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            # outer, lower divertor leg
+            {
+                "i": 45,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 46,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 47,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 48,
+                "boundaries": ["xinner"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 49,
+                "boundaries": [],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 50,
+                "boundaries": ["xouter"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 51,
+                "boundaries": ["xinner", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 52,
+                "boundaries": ["yupper"],
+                "fieldperp_global_yind": -1,
+            },
+            {
+                "i": 53,
+                "boundaries": ["xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
         dumps = []
-
-        # inner, lower divertor leg
-        dumps.append(
-            create_dump_file(
-                i=0,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "ylower"],
-                fieldperp_global_yind=-1,
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
             )
-        )
-        dumps.append(
-            create_dump_file(
-                i=1,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=2,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=3,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=4,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=5,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=6,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=7,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=8,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # inner core
-        dumps.append(
-            create_dump_file(
-                i=9,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=10,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=11,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=12,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=13,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=14,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=fieldperp_global_yind,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=15,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=16,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=17,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # inner, upper divertor leg
-        dumps.append(
-            create_dump_file(
-                i=18,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=19,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=20,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=21,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=22,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=23,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=24,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=25,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=26,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer, upper divertor leg
-        dumps.append(
-            create_dump_file(
-                i=27,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=28,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=29,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "ylower"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=30,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=31,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=32,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=33,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=34,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=35,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer core
-        dumps.append(
-            create_dump_file(
-                i=36,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=37,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=38,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=39,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=40,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=41,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=42,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=43,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=44,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-
-        # outer, lower divertor leg
-        dumps.append(
-            create_dump_file(
-                i=45,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=46,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=47,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=48,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=49,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=[],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=50,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=51,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xinner", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=52,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
-        dumps.append(
-            create_dump_file(
-                i=53,
-                tmpdir=tmp_path,
-                rng=rng,
-                grid_info=grid_info,
-                boundaries=["xouter", "yupper"],
-                fieldperp_global_yind=-1,
-            )
-        )
 
         expected = concatenate_data(
             dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -666,6 +666,164 @@ class TestCollect:
         )
 
     @pytest.mark.parametrize("squash", [False, True])
+    def test_singlenull_min_files_fieldperp_on_two_yproc_different_index(
+        self, tmp_path, squash
+    ):
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 7
+        fieldperp_yproc_ind = 1
+
+        rng = np.random.default_rng(104)
+
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": 2,
+            },
+            # core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": 7,
+            },
+            # outer divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        with pytest.raises(ValueError, match="Found FieldPerp"):
+            check_collected_data(
+                expected,
+                fieldperp_global_yind=fieldperp_global_yind,
+                doublenull=False,
+                path=tmp_path,
+                squash=squash,
+                collect_kwargs=collect_kwargs,
+            )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    def test_singlenull_min_files_fieldperp_on_two_yproc_same_index(
+        self, tmp_path, squash
+    ):
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 4
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * grid_info["MYSUB"] - 1
+
+        fieldperp_global_yind = 7
+        fieldperp_yproc_ind = 1
+
+        rng = np.random.default_rng(104)
+
+        dump_params = [
+            # inner divertor leg
+            {
+                "i": 0,
+                "boundaries": ["xinner", "xouter", "ylower"],
+                "fieldperp_global_yind": 7,
+            },
+            # core
+            {
+                "i": 1,
+                "boundaries": ["xinner", "xouter"],
+                "fieldperp_global_yind": 7,
+            },
+            # outer divertor leg
+            {
+                "i": 2,
+                "boundaries": ["xinner", "xouter", "yupper"],
+                "fieldperp_global_yind": -1,
+            },
+        ]
+        dumps = []
+        for p in dump_params:
+            dumps.append(
+                create_dump_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    **p,
+                )
+            )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        with pytest.raises(ValueError, match="Found FieldPerp"):
+            check_collected_data(
+                expected,
+                fieldperp_global_yind=fieldperp_global_yind,
+                doublenull=False,
+                path=tmp_path,
+                squash=squash,
+                collect_kwargs=collect_kwargs,
+            )
+
+    @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_singlenull(self, tmp_path, squash, collect_kwargs):
         grid_info = {}

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -82,6 +82,208 @@ def check_collected_data(
 class TestCollect:
     @pytest.mark.parametrize("squash", [False, True])
     @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_core_min_files(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 1
+        grid_info["NYPE"] = 1
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 7
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = -1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+
+        fieldperp_global_yind = 3
+        fieldperp_yproc_ind = 0
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # core
+        # core includes "ylower" and "yupper" even though there is no actual y-boundary
+        # because collect/squashoutput collect these points
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "xouter", "ylower", "yupper"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
+    def test_core(self, tmp_path, squash, squash_kwargs):
+        grid_info = {}
+        grid_info["iteration"] = 6
+        grid_info["MXSUB"] = 3
+        grid_info["MYSUB"] = 4
+        grid_info["MZSUB"] = 5
+        grid_info["MXG"] = 2
+        grid_info["MYG"] = 2
+        grid_info["MZG"] = 0
+        grid_info["NXPE"] = 3
+        grid_info["NYPE"] = 3
+        grid_info["NZPE"] = 1
+        grid_info["nx"] = grid_info["NXPE"] * grid_info["MXSUB"] + 2 * grid_info["MXG"]
+        grid_info["ny"] = grid_info["NYPE"] * grid_info["MYSUB"]
+        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+        grid_info["MZ"] = grid_info["nz"]
+        grid_info["ixseps1"] = 7
+        grid_info["ixseps2"] = 7
+        grid_info["jyseps1_1"] = -1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = grid_info["ny"] // 2
+
+        fieldperp_global_yind = 3
+        fieldperp_yproc_ind = 0
+
+        rng = np.random.default_rng(100)
+
+        dumps = []
+
+        # core
+        dumps.append(
+            create_dump_file(
+                i=0,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=1,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=2,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "ylower"],
+                fieldperp_global_yind=fieldperp_global_yind,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=3,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=4,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=[],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=5,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=6,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xinner", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=7,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+        dumps.append(
+            create_dump_file(
+                i=8,
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                boundaries=["xouter", "yupper"],
+                fieldperp_global_yind=-1,
+            )
+        )
+
+        expected = concatenate_data(
+            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
+        )
+
+        collect_kwargs = {"xguards": True, "yguards": "include_upper"}
+
+        check_collected_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=tmp_path,
+            squash=squash,
+            collect_kwargs=collect_kwargs,
+            squash_kwargs=squash_kwargs,
+        )
+
+    @pytest.mark.parametrize("squash", [False, True])
+    @pytest.mark.parametrize("squash_kwargs", squash_kwargs)
     def test_singlenull_min_files(self, tmp_path, squash, squash_kwargs):
         grid_info = {}
         grid_info["iteration"] = 6


### PR DESCRIPTION
Adds tests for `collect()` and `squashoutput()` to the test suite. The tests cover core, SOL, single-null, connected double-null and disconnected double-null topologies (the last two aren't really different because `collect()` doesn't need the separatrix positions `ixseps1` and `ixseps2`, but is included for completeness - limiter topology is missing, but is not really different from core or SOL for the same reason). The `xguards`, `yguards`, `tind`, `xind`, `yind` and `zind` arguments are all tested, as are the `compression` and `complevel` arguments to `squashoutput` (which verify that we get identical data when using compression). Edit: now added tests for different `MXG` and `MYG` values for one case.

If anyone can see anything significant missing, please add it!