### PR TITLE
Refactoring 'collect' functions/methods

### DIFF
--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -539,7 +539,16 @@ def _collect_from_one_proc(
 ):
     """Read part of a variable from one processor
 
-    For use in _collect_parallel()
+    Reads the part of the data from the file output by a single processor. Excludes
+    guard cells used only for communication between processors, but optionally includes
+    boundary cells.
+
+    Result is stored into the global array passed in the 'result'
+    argument - this avoids complicated concatenation of results from multiple
+    processors, and is also more convenient when using a shared memory array to gather
+    results from parallel workers.
+
+    The returned values are used for checks on FieldPerp variables.
 
     Parameters
     ----------

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -499,24 +499,15 @@ def _apply_step(data, dimensions, xstep, ystep):
     ystep : int or None
         Step to apply in the y-direction
     """
-    if xstep is not None or ystep is not None:
-        if dimensions == ("t", "x", "y", "z"):
-            data = data[:, :: xstep, :: ystep]
-        elif dimensions == ("x", "y", "z"):
-            data = data[:: xstep, :: ystep, :]
-        elif dimensions == ("t", "x", "y"):
-            data = data[:, :: xstep, :: ystep]
-        elif dimensions == ("t", "x", "z"):
-            data = data[:, :: xstep, :]
-        elif dimensions == ("x", "y"):
-            data = data[:: xstep, :: ystep]
-        elif dimensions == ("x", "z"):
-            data = data[:: xstep, :]
-        else:
-            raise ValueError(
-                "Incorrect dimensions {} applying steps in collect".format(dimensions)
-            )
-    return data
+    slices = [slice(None)] * len(dimensions)
+
+    if "x" in dimensions:
+        slices[dimensions.index("x")] = slice(None, None, xstep)
+
+    if "y" in dimensions:
+        slices[dimensions.index("y")] = slice(None, None, ystep)
+
+    return data[slices]
 
 
 def _collect_from_one_proc(

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -507,7 +507,7 @@ def _apply_step(data, dimensions, xstep, ystep):
     if "y" in dimensions:
         slices[dimensions.index("y")] = slice(None, None, ystep)
 
-    return data[slices]
+    return data[tuple(slices)]
 
 
 def _collect_from_one_proc(

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -239,8 +239,12 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
     if tind_auto:
         nt = grid_info["nt"]
         for i in range(1, nfiles):
-            t_array_ = getDataFile(i).read("t_array")
+            f = getDataFile(i)
+            t_array_ = f.read("t_array")
             nt = min(len(t_array_), nt)
+            if datafile_cache is None:
+                # close the DataFile if we are not keeping it in a cache
+                f.close()
         grid_info["nt"] = nt
 
     if info:

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -38,23 +38,26 @@ def findVar(varname, varlist):
     v = [name for name in varlist if name.lower() == varname.lower()]
     if len(v) == 1:
         # Found case match
-        print("Variable '%s' not found. Using '%s' instead" % (varname, v[0]))
+        print("Variable '{}' not found. Using '{}' instead".format(varname, v[0]))
         return v[0]
     elif len(v) > 1:
-        print("Variable '"+varname +
-              "' not found, and is ambiguous. Could be one of: "+str(v))
-        raise ValueError("Variable '"+varname+"' not found")
+        print(
+            "Variable '{}' not found, and is ambiguous. Could be one of: {}"
+            .format(varname, v)
+        )
+        raise ValueError("Variable '{}' not found".format(varname))
 
     # None found. Check if it's an abbreviation
     v = [name for name in varlist
          if name[:len(varname)].lower() == varname.lower()]
     if len(v) == 1:
-        print("Variable '%s' not found. Using '%s' instead" % (varname, v[0]))
+        print("Variable '{}' not found. Using '{}' instead".format(varname, v[0]))
         return v[0]
-
-    if len(v) > 1:
-        print("Variable '"+varname +
-              "' not found, and is ambiguous. Could be one of: "+str(v))
+    elif len(v) > 1:
+        print(
+            "Variable '{}' not found, and is ambiguous. Could be one of: {}"
+            .format(varname, v)
+        )
     raise ValueError("Variable '"+varname+"' not found")
 
 
@@ -86,7 +89,7 @@ def _convert_to_nice_slice(r, N, name="range"):
     """
 
     if N == 0:
-        raise ValueError("No data available in %s"%name)
+        raise ValueError("No data available in {}".format(name))
     if r is None:
         temp_slice = slice(N)
     elif isinstance(r, slice):
@@ -95,7 +98,7 @@ def _convert_to_nice_slice(r, N, name="range"):
         if r >= N or r <-N:
             # raise out of bounds error as if we'd tried to index the array with r
             # without this, would return an empty array instead
-            raise IndexError(name+" index out of range, value was "+str(r))
+            raise IndexError("{} index out of range, value was {}".format(name, r))
         elif r == -1:
             temp_slice = slice(r, None)
         else:
@@ -249,18 +252,18 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
 
     if info:
         print(
-            "mxsub = %d mysub = %d mz = %d\n"
-            % (grid_info["mxsub"], grid_info["mysub"], grid_info["nz"])
+            "mxsub = {} mysub = {} mz = {}\n"
+            .format(grid_info["mxsub"], grid_info["mysub"], grid_info["nz"])
         )
 
         print(
-            "nxpe = %d, nype = %d, npes = %d\n"
-            % (grid_info["nxpe"], grid_info["nype"], grid_info["npes"])
+            "nxpe = {}, nype = {}, npes = {}\n"
+            .format(grid_info["nxpe"], grid_info["nype"], grid_info["npes"])
         )
         if grid_info["npes"] < nfiles:
-            print("WARNING: More files than expected (" + str(grid_info["npes"]) + ")")
+            print("WARNING: More files than expected ({})".format(grid_info["npes"]))
         elif grid_info["npes"] > nfiles:
-            print("WARNING: Some files missing. Expected " + str(grid_info["npes"]))
+            print("WARNING: Some files missing. Expected {}".format(grid_info["npes"]))
 
     if not any(dim in dimensions for dim in ('x', 'y', 'z')):
         # Not a Field (i.e. no spatial dependence) so only read from the 0'th file
@@ -268,8 +271,8 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
             if not dimensions[0] == 't':
                 # 't' should be the first dimension in the list if present
                 raise ValueError(
-                    varname + " has a 't' dimension, but it is not the first dimension "
-                    "in dimensions=" + str(dimensions)
+                    "{} has a 't' dimension, but it is not the first dimension "
+                    "in dimensions={}".format(varname, dimensions)
                 )
             data = f.read(varname, ranges = [tind] + (ndims - 1) * [None])
         else:
@@ -350,7 +353,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
             data = data[:: xind.step, :]
         else:
             raise ValueError(
-                "Incorrect dimensions " + str(dimensions) + " applying steps in collect"
+                "Incorrect dimensions {} applying steps in collect".format(dimensions)
             )
 
     # Finished looping over all files
@@ -555,8 +558,8 @@ def _collect_from_one_proc(
             if not dimensions[0] == "t":
                 # 't' should be the first dimension in the list if present
                 raise ValueError(
-                    varname + " has a 't' dimension, but it is not the first dimension "
-                    "in dimensions=" + str(dimensions)
+                    "{} has a 't' dimension, but it is not the first dimension "
+                    "in dimensions={}".format(varname, dimensions)
                 )
             result[:] = datafile.read(varname, ranges=[tind] + (ndims - 1) * [None])
         else:
@@ -622,25 +625,17 @@ def _collect_from_one_proc(
 
     if info:
         sys.stdout.write(
-            "\rReading from "
-            + str(i)
-            + ": ["
-            + str(xstart)
-            + "-"
-            + str(xstop - 1)
-            + "]["
-            + str(ystart)
-            + "-"
-            + str(ystop - 1)
-            + "] -> ["
-            + str(xgstart)
-            + "-"
-            + str(xgstop - 1)
-            + "]["
-            + str(ygstart)
-            + "-"
-            + str(ygstop - 1)
-            + "]\n"
+            "\rReading from {}: [{}-{}][{}-{}] -> [{}-{}][{}-{}]\n".format(
+                i,
+                xstart,
+                xstop - 1,
+                ystart,
+                ystop - 1,
+                xgstart,
+                xgstop - 1,
+                ygstart,
+                ygstop - 1
+            )
         )
 
     if is_fieldperp:
@@ -905,7 +900,7 @@ def _get_grid_info(f, *, xguards, yguards, tind, xind, yind, zind, all_vars_info
     def load_and_check(varname):
         var = f.read(varname)
         if var is None:
-            raise ValueError("Missing " + varname + " variable")
+            raise ValueError("Missing {} variable".format(varname))
         return var
 
     mz = int(load_and_check("MZ"))

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -421,32 +421,8 @@ def _collect_from_single_file(
     if not yguards:
         yind = slice(yind.start + myg, yind.stop + myg, yind.step)
 
-    if dimensions == ():
-        ranges = []
-    elif dimensions == ("t",):
-        ranges = [tind]
-    elif dimensions == ("x", "y"):
-        # Field2D
-        ranges = [xind, yind]
-    elif dimensions == ("x", "z"):
-        # FieldPerp
-        ranges = [xind, zind]
-    elif dimensions == ("t", "x", "y"):
-        # evolving Field2D
-        ranges = [tind, xind, yind]
-    elif dimensions == ("t", "x", "z"):
-        # evolving FieldPerp
-        ranges = [tind, xind, zind]
-    elif dimensions == ("x", "y", "z"):
-        # Field3D
-        ranges = [xind, yind, zind]
-    elif dimensions == ("t", "x", "y", "z"):
-        # evolving Field3D
-        ranges = [tind, xind, yind, zind]
-    else:
-        # Not a Field, so do not support slicing.
-        # For example, may be a string.
-        ranges = None
+    dim_ranges = {"t": tind, "x": xind, "y": yind, "z": zind}
+    ranges = [dim_ranges.get(dim, None) for dim in dimensions]
 
     data = f.read(varname, ranges)
     var_attributes = f.attributes(varname)

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -664,7 +664,7 @@ def _collect_from_one_proc(
     global_slices = tuple(global_slices)
 
     if info:
-        sys.stdout.write(
+        print(
             "\rReading from {}: [{}-{}][{}-{}] -> [{}-{}][{}-{}]\n".format(
                 i,
                 xstart,

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -903,6 +903,12 @@ def _check_fieldperp_attributes(
     var_attributes,
     temp_f_attributes,
 ):
+    """
+    Check attributes for a FieldPerp from one file. If the FieldPerp was actually
+    written to that file, update the 'global' attributes of the FieldPerp. If data for
+    the FieldPerp has already been found, check that the y-index of the processors is
+    the same and the 'yindex_global' is the same.
+    """
     if temp_yindex is not None:
         # Found actual data for a FieldPerp, so update FieldPerp properties
         # and check they are unique

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -328,23 +328,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None, path=".",
             f.close()
 
     # if a step was requested in x or y, need to apply it here
-    if xind.step is not None or yind.step is not None:
-        if dimensions == ("t", "x", "y", "z"):
-            data = data[:, :: xind.step, :: yind.step]
-        elif dimensions == ("x", "y", "z"):
-            data = data[:: xind.step, :: yind.step, :]
-        elif dimensions == ("t", "x", "y"):
-            data = data[:, :: xind.step, :: yind.step]
-        elif dimensions == ("t", "x", "z"):
-            data = data[:, :: xind.step, :]
-        elif dimensions == ("x", "y"):
-            data = data[:: xind.step, :: yind.step]
-        elif dimensions == ("x", "z"):
-            data = data[:: xind.step, :]
-        else:
-            raise ValueError(
-                "Incorrect dimensions {} applying steps in collect".format(dimensions)
-            )
+    data = _apply_step(data, dimensions, xind.step, yind.step)
 
     # Finished looping over all files
     if info:
@@ -498,6 +482,41 @@ def _read_scalar(f, varname, dimensions, var_attributes, tind):
         # No time or space dimensions, so no slicing
         data = f.read(varname)
     return BoutArray(data, attributes=var_attributes)
+
+
+def _apply_step(data, dimensions, xstep, ystep):
+    """
+    Apply steps of xind and yind slices to an array
+
+    Parameters
+    ----------
+    data : np.Array
+        Data array to be sliced
+    dimensions : tuple
+        Dimensions of data
+    xstep : int or None
+        Step to apply in the x-direction
+    ystep : int or None
+        Step to apply in the y-direction
+    """
+    if xstep is not None or ystep is not None:
+        if dimensions == ("t", "x", "y", "z"):
+            data = data[:, :: xstep, :: ystep]
+        elif dimensions == ("x", "y", "z"):
+            data = data[:: xstep, :: ystep, :]
+        elif dimensions == ("t", "x", "y"):
+            data = data[:, :: xstep, :: ystep]
+        elif dimensions == ("t", "x", "z"):
+            data = data[:, :: xstep, :]
+        elif dimensions == ("x", "y"):
+            data = data[:: xstep, :: ystep]
+        elif dimensions == ("x", "z"):
+            data = data[:: xstep, :]
+        else:
+            raise ValueError(
+                "Incorrect dimensions {} applying steps in collect".format(dimensions)
+            )
+    return data
 
 
 def _collect_from_one_proc(

--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -624,9 +624,20 @@ def _collect_from_one_proc(
     xstart, xstop, xgstart, xgstop, inrange = _get_x_range(
         xguards, xind, pe_xind, nxpe, mxsub, mxg, inrange
     )
-    ystart, ystop, ygstart, ygstop, inrange = _get_y_range(
-        yguards, yind, pe_yind, nype, yproc_upper_target, mysub, myg, inrange
-    )
+    if is_fieldperp:
+        # FieldPerps do not have a y-dimension, so cannot be sliced in y and should
+        # always be read regardless of the value of yind (so we should not change
+        # inrange by checking the y-range).
+        # ystart, ystop, ygstart and ygstop are set only to avoid errors in 'info'
+        # messages.
+        ystart = 0
+        ystop = 1
+        ygstart = 0
+        ygstop = 1
+    else:
+        ystart, ystop, ygstart, ygstop, inrange = _get_y_range(
+            yguards, yind, pe_yind, nype, yproc_upper_target, mysub, myg, inrange
+        )
 
     if not inrange:
         return None, None  # Don't need this file

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -953,8 +953,9 @@ class BoutOutputs(object):
         with the maximum number of available processors. If set to an int, use that many
         processes.
 
-    **kwargs
-        keyword arguments that are passed through to collect()
+    Other parameters
+    ----------------
+    keyword arguments that are passed through to collect()
 
     Examples
     --------

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -4,6 +4,7 @@ OMFIT
 
 """
 
+from collections import OrderedDict
 import copy
 import glob
 import io
@@ -1108,8 +1109,6 @@ class BoutOutputs(object):
         """
         Initialise private members used for caching of data variables
         """
-        from collections import OrderedDict
-
         self._datacache = OrderedDict()
         if self._caching is not True:
             # Track the size of _datacache and limit it to a maximum of _caching

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -1429,6 +1429,12 @@ class BoutOutputs(object):
                 return BoutArray(
                     self._root_file.read(varname), attributes=var_attributes
                 )
+        elif any(dim not in ("t", "x", "y", "z") for dim in dimensions):
+            raise ValueError(
+                "Dimensions {} of {} contain spatial dimensions but also have dimensions "
+                "that are not 't', 'x', 'y' or 'z'. This is not supported by parallel "
+                "reading. Try reading with parallel=False".format(dimensions, varname)
+            )
 
         is_fieldperp = dimensions in (("t", "x", "z"), ("x", "z"))
 

--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -1063,16 +1063,16 @@ class BoutOutputs(object):
 
         if self._info:
             print(
-                "mxsub = %d mysub = %d mz = %d\n"
-                % (
+                "mxsub = {} mysub = {} mz = {}\n"
+                .format(
                     self.grid_info["mxsub"],
                     self.grid_info["mysub"],
                     self.grid_info["nz"],
                 )
             )
             print(
-                "nxpe = %d, nype = %d, npes = %d\n"
-                % (
+                "nxpe = {}, nype = {}, npes = {}\n"
+                .format(
                     self.grid_info["nxpe"],
                     self.grid_info["nype"],
                     self.grid_info["npes"],
@@ -1080,10 +1080,12 @@ class BoutOutputs(object):
             )
             if self.grid_info["npes"] < len(self._file_list):
                 print(
-                    "WARNING: More files than expected (" + str(grid_info["npes"]) + ")"
+                    "WARNING: More files than expected ({})".format(grid_info["npes"])
                 )
             elif self.grid_info["npes"] > len(self._file_list):
-                print("WARNING: Some files missing. Expected " + str(grid_info["npes"]))
+                print(
+                    "WARNING: Some files missing. Expected {}".format(grid_info["npes"])
+                )
 
         # Initialise private variables
         if self._caching:
@@ -1263,7 +1265,7 @@ class BoutOutputs(object):
             DataFileCache = None
         # read and write the data
         for v in self.varNames:
-            print("processing " + v)
+            print("processing {}".format(v))
             data = collect(
                 v,
                 path=backupdir,
@@ -1302,9 +1304,8 @@ class BoutOutputs(object):
                         # FieldPerp?
                         # check is not perfect, fails if ny=nz
                         raise ValueError(
-                            "Error: Found FieldPerp '"
-                            + v
-                            + "'. This case is not currently handled by BoutOutputs.redistribute()."
+                            "Error: Found FieldPerp '{}'. This case is not currently "
+                            "handled by BoutOutputs.redistribute().".format(v)
                         )
                     outfile.write(
                         v,
@@ -1319,9 +1320,8 @@ class BoutOutputs(object):
                         # evolving Field2D, but this case is not handled
                         # check is not perfect, fails if ny=nx and nx=nt
                         raise ValueError(
-                            "Error: Found evolving Field2D '"
-                            + v
-                            + "'. This case is not currently handled by BoutOutputs.redistribute()."
+                            "Error: Found evolving Field2D '{}'. This case is not "
+                            "currently handled by BoutOutputs.redistribute().".format(v)
                         )
                     outfile.write(
                         v,
@@ -1399,8 +1399,8 @@ class BoutOutputs(object):
             "strict")]
         if unsupported_kwargs:
             raise ValueError(
-                "kwargs " + str(unsupported_kwargs) + " are not supported when "
-                "parallel is not False"
+                "kwargs {} are not supported when parallel is not False"
+                .format(unsupported_kwargs)
             )
 
         if tind_auto:

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -119,7 +119,9 @@ def squashoutput(
 
     if os.path.isfile(fullpath) and not append:
         raise ValueError(
-            fullpath + " already exists. Collect may try to read from this file, which is presumably not desired behaviour.")
+            "{} already exists. Collect may try to read from this file, which is "
+            "presumably not desired behaviour.".format(fullpath)
+        )
 
     # useful object from BOUT pylib to access output data
     outputs = BoutOutputs(


### PR DESCRIPTION
Reduces duplication of code between `collect.py` and `BoutOutputs` in `data.py`. Splits off some chunks of code into separate utility functions to make function bodies shorter.

This PR actually manages to increase the number of lines of code slightly, but I think that's because I `black`-formatted the changes...