### PR TITLE
Fix for collect() when t_array is missing

### DIFF
--- a/boutdata/collect.py
+++ b/boutdata/collect.py
@@ -1015,7 +1015,10 @@ def _get_grid_info(
     ny_inner = int(load_and_check("ny_inner"))
     is_doublenull = load_and_check("jyseps2_1") != load_and_check("jyseps1_2")
 
-    nt = len(load_and_check("t_array"))
+    if "t_array" in f.keys():
+        nt = len(f.read("t_array"))
+    else:
+        nt = 1
     nx = nxpe * mxsub + 2 * mxg if xguards else nxpe * mxsub
 
     if yguards:

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -76,6 +76,84 @@ expected_attributes = {
 }
 
 
+def make_grid_info(
+    *, mxg=2, myg=2, nxpe=1, nype=1, ixseps1=None, ixseps2=None, xpoints=0
+):
+    """
+    Create a dict of parameters used for creating test data
+
+    Parameters
+    ----------
+    mxg : int, optional
+        Number of guard cells in the x-direction
+    myg : int, optional
+        Number of guard cells in the y-direction
+    nxpe : int, optional
+        Number of processes in the x-direction
+    nype : int, optional
+        Number of processes in the y-direction
+    ixseps1 : int, optional
+        x-index (where indexing includes boundary points) of point just outside
+        first separatrix
+    ixseps2 : int, optional
+        x-index (where indexing includes boundary points) of point just outside
+        second separatrix
+    xpoints : int, optional
+        Number of X-points.
+    """
+    grid_info = {}
+    grid_info["iteration"] = 6
+    grid_info["MXSUB"] = 3
+    grid_info["MYSUB"] = 4
+    grid_info["MZSUB"] = 5
+    grid_info["MXG"] = mxg
+    grid_info["MYG"] = myg
+    grid_info["MZG"] = 0
+    grid_info["NXPE"] = nxpe
+    grid_info["NYPE"] = nype
+    grid_info["NZPE"] = 1
+    grid_info["nx"] = nxpe * grid_info["MXSUB"] + 2 * mxg
+    grid_info["ny"] = nype * grid_info["MYSUB"]
+    grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
+    grid_info["MZ"] = grid_info["nz"]
+    if ixseps1 is None:
+        grid_info["ixseps1"] = grid_info["nx"]
+    else:
+        grid_info["ixseps1"] = ixseps1
+    if ixseps2 is None:
+        grid_info["ixseps2"] = grid_info["nx"]
+    else:
+        grid_info["ixseps2"] = ixseps2
+    if xpoints == 0:
+        grid_info["jyseps1_1"] = -1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = grid_info["ny"]
+    elif xpoints == 1:
+        if nype < 3:
+            raise ValueError(f"nype={nype} not enough for single-null")
+        yproc_per_region = nype // 3
+        grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
+        grid_info["ny_inner"] = grid_info["ny"] // 2
+        grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
+        grid_info["jyseps2_2"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
+    elif xpoints == 2:
+        if nype < 6:
+            raise ValueError(f"nype={nype} not enough for single-null")
+        yproc_per_region = nype // 6
+        grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_1"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
+        grid_info["ny_inner"] = 3 * yproc_per_region * grid_info["MYSUB"]
+        grid_info["jyseps1_2"] = 4 * yproc_per_region * grid_info["MYSUB"] - 1
+        grid_info["jyseps2_2"] = 5 * yproc_per_region * grid_info["MYSUB"] - 1
+    else:
+        raise ValueError(f"Unsupported value for xpoints: {xpoints}")
+
+    return grid_info
+
+
 def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_yind):
     """
     Create a netCDF file mocking up a BOUT++ output file, and also return the data

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -324,7 +324,111 @@ def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_
     return result
 
 
-def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
+def create_restart_file(*, i, tmpdir, rng, grid_info, fieldperp_global_yind):
+    """
+    Create a netCDF file mocking up a BOUT++ output file, and also return the data
+    without guard cells
+
+    Parameters
+    ----------
+    i : int
+        Number of the output file
+    tmpdir : pathlib.Path
+        Directory to write the dump file in
+    rng : numpy.random.Generator
+        Random number generator to create data
+    grid_info : dict
+        Dictionary containing grid sizes, etc
+    fieldperp_global_yind : int
+        Global y-index for a FieldPerp (should be -1 if FieldPerp is not on this
+        processor).
+
+    Returns
+    -------
+    Dict of scalars and numpy arrays
+    """
+    mxg = grid_info["MXG"]
+    myg = grid_info["MYG"]
+    mzg = grid_info["MZG"]
+    localnx = grid_info["MXSUB"] + 2 * mxg
+    localny = grid_info["MYSUB"] + 2 * myg
+    localnz = grid_info["MZSUB"] + 2 * mzg
+
+    with Dataset(tmpdir.joinpath("BOUT.restart." + str(i) + ".nc"), "w") as outputfile:
+        outputfile.createDimension("x", localnx)
+        outputfile.createDimension("y", localny)
+        outputfile.createDimension("z", localnz)
+
+        # Create slices for returned data without guard cells
+        xslice = slice(mxg, None if mxg == 0 else -mxg)
+        yslice = slice(myg, None if myg == 0 else -myg)
+        zslice = slice(mzg, None if mzg == 0 else -mzg)
+
+        result = {}
+
+        # Field3D
+        def create3D(name):
+            var = outputfile.createVariable(name, float, ("x", "y", "z"))
+
+            data = rng.random((localnx, localny, localnz))
+            var[:] = data
+            for key, value in expected_attributes[name].items():
+                var.setncattr(key, value)
+
+            result[name] = data[xslice, yslice, zslice]
+
+        create3D("field3d_1")
+        create3D("field3d_2")
+
+        # Field2D
+        def create2D(name):
+            var = outputfile.createVariable(name, float, ("x", "y"))
+
+            data = rng.random((localnx, localny))
+            var[:] = data
+            for key, value in expected_attributes[name].items():
+                var.setncattr(key, value)
+
+            result[name] = data[xslice, yslice]
+
+        create2D("field2d_1")
+        create2D("field2d_2")
+
+        # FieldPerp
+        def createPerp(name):
+            var = outputfile.createVariable(name, float, ("x", "z"))
+
+            data = rng.random((localnx, localnz))
+            var[:] = data
+            for key, value in expected_attributes[name].items():
+                var.setncattr(key, value)
+            var.setncattr("yindex_global", fieldperp_global_yind)
+
+            result[name] = data[xslice, zslice]
+
+        createPerp("fieldperp_1")
+        createPerp("fieldperp_2")
+
+        # Scalar
+        def createScalar(name, value):
+            var = outputfile.createVariable(name, type(value))
+
+            var[...] = value
+
+            result[name] = value
+
+        createScalar("BOUT_VERSION", 4.31)
+        for key, value in grid_info.items():
+            createScalar(key, value)
+        nxpe = grid_info["NXPE"]
+        createScalar("PE_XIND", i % nxpe)
+        createScalar("PE_YIND", i // nxpe)
+        createScalar("MYPE", i)
+
+    return result
+
+
+def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind, has_t_dim=True):
     """
     Joins together lists of data arrays for expected results from each process into a
     global array.
@@ -351,16 +455,17 @@ def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
     if npes % nxpe != 0:
         raise ValueError("nxpe={} does not divide len(data_list)={}".format(nxpe, npes))
 
-    for var in ("field3d_t_1", "field3d_t_2", "field2d_t_1", "field2d_t_2"):
-        # Join in x-direction
-        parts = [
-            np.concatenate(
-                [data_list[j][var] for j in range(i * nxpe, (i + 1) * nxpe)], axis=1
-            )
-            for i in range(nype)
-        ]
-        # Join in y-direction
-        result[var] = np.concatenate(parts, axis=2)
+    if has_t_dim:
+        for var in ("field3d_t_1", "field3d_t_2", "field2d_t_1", "field2d_t_2"):
+            # Join in x-direction
+            parts = [
+                np.concatenate(
+                    [data_list[j][var] for j in range(i * nxpe, (i + 1) * nxpe)], axis=1
+                )
+                for i in range(nype)
+            ]
+            # Join in y-direction
+            result[var] = np.concatenate(parts, axis=2)
 
     for var in ("field3d_1", "field3d_2", "field2d_1", "field2d_2"):
         # Join in x-direction
@@ -373,17 +478,18 @@ def concatenate_data(data_list, *, nxpe, fieldperp_yproc_ind):
         # Join in y-direction
         result[var] = np.concatenate(parts, axis=1)
 
-    for var in ("fieldperp_t_1", "fieldperp_t_2"):
-        # Join in x-direction
-        result[var] = np.concatenate(
-            [
-                data_list[j][var]
-                for j in range(
-                    fieldperp_yproc_ind * nxpe, (fieldperp_yproc_ind + 1) * nxpe
-                )
-            ],
-            axis=1,
-        )
+    if has_t_dim:
+        for var in ("fieldperp_t_1", "fieldperp_t_2"):
+            # Join in x-direction
+            result[var] = np.concatenate(
+                [
+                    data_list[j][var]
+                    for j in range(
+                        fieldperp_yproc_ind * nxpe, (fieldperp_yproc_ind + 1) * nxpe
+                    )
+                ],
+                axis=1,
+            )
 
     for var in ("fieldperp_1", "fieldperp_2"):
         # Join in x-direction

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -12,6 +12,7 @@ from boutdata.tests.make_test_data import (
     create_dump_file,
     concatenate_data,
     expected_attributes,
+    make_grid_info,
     remove_xboundaries,
     remove_yboundaries,
     remove_yboundaries_upper_divertor,
@@ -127,83 +128,6 @@ def check_collected_data(
 
 
 class TestCollect:
-    def make_grid_info(
-        self, *, mxg=2, myg=2, nxpe=1, nype=1, ixseps1=None, ixseps2=None, xpoints=0
-    ):
-        """
-        Create a dict of parameters used for creating test data
-
-        Parameters
-        ----------
-        mxg : int, optional
-            Number of guard cells in the x-direction
-        myg : int, optional
-            Number of guard cells in the y-direction
-        nxpe : int, optional
-            Number of processes in the x-direction
-        nype : int, optional
-            Number of processes in the y-direction
-        ixseps1 : int, optional
-            x-index (where indexing includes boundary points) of point just outside
-            first separatrix
-        ixseps2 : int, optional
-            x-index (where indexing includes boundary points) of point just outside
-            second separatrix
-        xpoints : int, optional
-            Number of X-points.
-        """
-        grid_info = {}
-        grid_info["iteration"] = 6
-        grid_info["MXSUB"] = 3
-        grid_info["MYSUB"] = 4
-        grid_info["MZSUB"] = 5
-        grid_info["MXG"] = mxg
-        grid_info["MYG"] = myg
-        grid_info["MZG"] = 0
-        grid_info["NXPE"] = nxpe
-        grid_info["NYPE"] = nype
-        grid_info["NZPE"] = 1
-        grid_info["nx"] = nxpe * grid_info["MXSUB"] + 2 * mxg
-        grid_info["ny"] = nype * grid_info["MYSUB"]
-        grid_info["nz"] = grid_info["NZPE"] * grid_info["MZSUB"]
-        grid_info["MZ"] = grid_info["nz"]
-        if ixseps1 is None:
-            grid_info["ixseps1"] = grid_info["nx"]
-        else:
-            grid_info["ixseps1"] = ixseps1
-        if ixseps2 is None:
-            grid_info["ixseps2"] = grid_info["nx"]
-        else:
-            grid_info["ixseps2"] = ixseps2
-        if xpoints == 0:
-            grid_info["jyseps1_1"] = -1
-            grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-            grid_info["ny_inner"] = grid_info["ny"] // 2
-            grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-            grid_info["jyseps2_2"] = grid_info["ny"]
-        elif xpoints == 1:
-            if nype < 3:
-                raise ValueError(f"nype={nype} not enough for single-null")
-            yproc_per_region = nype // 3
-            grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
-            grid_info["jyseps2_1"] = grid_info["ny"] // 2 - 1
-            grid_info["ny_inner"] = grid_info["ny"] // 2
-            grid_info["jyseps1_2"] = grid_info["ny"] // 2 - 1
-            grid_info["jyseps2_2"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
-        elif xpoints == 2:
-            if nype < 6:
-                raise ValueError(f"nype={nype} not enough for single-null")
-            yproc_per_region = nype // 6
-            grid_info["jyseps1_1"] = yproc_per_region * grid_info["MYSUB"] - 1
-            grid_info["jyseps2_1"] = 2 * yproc_per_region * grid_info["MYSUB"] - 1
-            grid_info["ny_inner"] = 3 * yproc_per_region * grid_info["MYSUB"]
-            grid_info["jyseps1_2"] = 4 * yproc_per_region * grid_info["MYSUB"] - 1
-            grid_info["jyseps2_2"] = 5 * yproc_per_region * grid_info["MYSUB"] - 1
-        else:
-            raise ValueError(f"Unsupported value for xpoints: {xpoints}")
-
-        return grid_info
-
     @pytest.mark.parametrize("squash_params", squash_params_list)
     @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
     def test_core_min_files(self, tmp_path, squash_params, collect_kwargs):
@@ -212,7 +136,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info()
+        grid_info = make_grid_info()
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -262,7 +186,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nxpe=3, nype=3)
+        grid_info = make_grid_info(nxpe=3, nype=3)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -318,7 +242,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(ixseps1=0, ixseps2=0)
+        grid_info = make_grid_info(ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -366,7 +290,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nxpe=3, nype=3, ixseps1=0, ixseps2=0)
+        grid_info = make_grid_info(nxpe=3, nype=3, ixseps1=0, ixseps2=0)
 
         fieldperp_global_yind = 3
         fieldperp_yproc_ind = 0
@@ -420,7 +344,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
+        grid_info = make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -473,7 +397,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
+        grid_info = make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 1
         fieldperp_yproc_ind = 0
@@ -526,7 +450,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
+        grid_info = make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 14
         fieldperp_yproc_ind = 2
@@ -581,7 +505,7 @@ class TestCollect:
 
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
-        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
+        grid_info = make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -637,7 +561,7 @@ class TestCollect:
 
         collect_kwargs = {"xguards": True, "yguards": "include_upper"}
 
-        grid_info = self.make_grid_info(nype=3, ixseps1=4, xpoints=1)
+        grid_info = make_grid_info(nype=3, ixseps1=4, xpoints=1)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -690,7 +614,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
+        grid_info = make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -777,7 +701,7 @@ class TestCollect:
         means there is at least one process in each region with no edges touching
         another region.
         """
-        grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
+        grid_info = make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -1212,7 +1136,7 @@ class TestCollect:
             "zind": zind,
         }
 
-        grid_info = self.make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
+        grid_info = make_grid_info(nxpe=3, nype=9, ixseps1=7, xpoints=1)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -1294,7 +1218,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nype=6, ixseps1=4, ixseps2=4, xpoints=2)
+        grid_info = make_grid_info(nype=6, ixseps1=4, ixseps2=4, xpoints=2)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -1352,9 +1276,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(
-            nxpe=3, nype=18, ixseps1=7, ixseps2=7, xpoints=2
-        )
+        grid_info = make_grid_info(nxpe=3, nype=18, ixseps1=7, ixseps2=7, xpoints=2)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4
@@ -1461,7 +1383,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(nype=6, ixseps1=3, ixseps2=5, xpoints=2)
+        grid_info = make_grid_info(nype=6, ixseps1=3, ixseps2=5, xpoints=2)
 
         fieldperp_global_yind = 7
         fieldperp_yproc_ind = 1
@@ -1523,7 +1445,7 @@ class TestCollect:
         """
         squash, squash_kwargs = squash_params
 
-        grid_info = self.make_grid_info(
+        grid_info = make_grid_info(
             mxg=mxg, myg=myg, nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
         )
 
@@ -1643,9 +1565,7 @@ class TestCollect:
         edges touching another region. This test checks some compression options that
         can be used with `squashoutput()`, verifying that they do not modify data.
         """
-        grid_info = self.make_grid_info(
-            nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2
-        )
+        grid_info = make_grid_info(nxpe=3, nype=18, ixseps1=6, ixseps2=11, xpoints=2)
 
         fieldperp_global_yind = 19
         fieldperp_yproc_ind = 4

--- a/boutdata/tests/test_restart.py
+++ b/boutdata/tests/test_restart.py
@@ -1,0 +1,177 @@
+from glob import glob
+import numpy as np
+import numpy.testing as npt
+
+from boutdata.collect import collect
+from boutdata import restart
+
+from boutdata.tests.make_test_data import (
+    create_restart_file,
+    concatenate_data,
+    expected_attributes,
+    make_grid_info,
+)
+
+
+def check_redistributed_data(
+    expected,
+    *,
+    fieldperp_global_yind,
+    path,
+):
+    """
+    Use `collect()` to read 'actual' data from the files. Test that 'actual' and
+    'expected' data and attributes match.
+
+    Parameters
+    ----------
+    expected : dict {str: numpy array}
+        dict of expected data (key is name, value is scalar or numpy array of data).
+        Arrays should be global (not per-process).
+    fieldperp_global_yind : int
+        Global y-index where FieldPerps are expected to be defined.
+    path : pathlib.Path or str
+        Path to collect data from.
+    """
+    expected_different = ["MXSUB", "MYSUB", "NXPE", "NYPE"]
+    for varname in expected:
+        if varname in expected_different:
+            # These variables are expected to be changed by restart.redistribute
+            continue
+        actual = collect(
+            varname, path=path, prefix="BOUT.restart", xguards=False, yguards=False
+        )
+        npt.assert_array_equal(expected[varname], actual)
+        actual_keys = list(actual.attributes.keys())
+        if varname in expected_attributes:
+            for a in expected_attributes[varname]:
+                assert actual.attributes[a] == expected_attributes[varname][a]
+                actual_keys.remove(a)
+
+        if "fieldperp" in varname:
+            assert actual.attributes["yindex_global"] == fieldperp_global_yind
+            actual_keys.remove("yindex_global")
+
+        assert actual_keys == ["bout_type"]
+
+        if "field3d" in varname:
+            assert actual.attributes["bout_type"] == "Field3D"
+        elif "field2d" in varname:
+            assert actual.attributes["bout_type"] == "Field2D"
+        elif "fieldperp" in varname:
+            assert actual.attributes["bout_type"] == "FieldPerp"
+        else:
+            assert actual.attributes["bout_type"] == "scalar"
+
+
+class TestRestart:
+    def test_redistribute_connected_doublenull(self, tmp_path):
+        """
+        Check for a connected double-null case using a large number of processes.
+        'Large' means there is at least one process in each region with no edges
+        touching another region.
+        """
+        npes_redistributed = 6
+
+        grid_info = make_grid_info(nxpe=3, nype=18, ixseps1=7, ixseps2=7, xpoints=2)
+
+        fieldperp_global_yind = 19
+        fieldperp_yproc_ind = 4
+
+        rng = np.random.default_rng(108)
+
+        restart_params = [
+            # inner, lower divertor leg
+            (0, -1),
+            (1, -1),
+            (2, -1),
+            (3, -1),
+            (4, -1),
+            (5, -1),
+            (6, -1),
+            (7, -1),
+            (8, -1),
+            # inner core
+            (9, -1),
+            (10, -1),
+            (11, -1),
+            (12, fieldperp_global_yind),
+            (13, fieldperp_global_yind),
+            (14, fieldperp_global_yind),
+            (15, -1),
+            (16, -1),
+            (17, -1),
+            # inner, upper divertor leg
+            (18, -1),
+            (19, -1),
+            (20, -1),
+            (21, -1),
+            (22, -1),
+            (23, -1),
+            (24, -1),
+            (25, -1),
+            (26, -1),
+            # outer, upper divertor leg
+            (27, -1),
+            (28, -1),
+            (29, -1),
+            (30, -1),
+            (31, -1),
+            (32, -1),
+            (33, -1),
+            (34, -1),
+            (35, -1),
+            # outer core
+            (36, -1),
+            (37, -1),
+            (38, -1),
+            (39, -1),
+            (40, -1),
+            (41, -1),
+            (42, -1),
+            (43, -1),
+            (44, -1),
+            # outer, lower divertor leg
+            (45, -1),
+            (46, -1),
+            (47, -1),
+            (48, -1),
+            (49, -1),
+            (50, -1),
+            (51, -1),
+            (52, -1),
+            (53, -1),
+        ]
+        restarts = []
+        for i, fieldperp_yind in restart_params:
+            restarts.append(
+                create_restart_file(
+                    tmpdir=tmp_path,
+                    rng=rng,
+                    grid_info=grid_info,
+                    i=i,
+                    fieldperp_global_yind=fieldperp_yind,
+                )
+            )
+
+        expected = concatenate_data(
+            restarts,
+            nxpe=grid_info["NXPE"],
+            fieldperp_yproc_ind=fieldperp_yproc_ind,
+            has_t_dim=False,
+        )
+
+        new_path = tmp_path.joinpath("new_restarts")
+        new_path.mkdir()
+        restart.redistribute(npes=npes_redistributed, path=tmp_path, output=new_path)
+
+        # Check the right number of files have been created
+        new_files = glob(str(new_path.joinpath("*")))
+        assert len(new_files) == npes_redistributed
+
+        # Check data in redistributed restart files
+        check_redistributed_data(
+            expected,
+            fieldperp_global_yind=fieldperp_global_yind,
+            path=new_path,
+        )


### PR DESCRIPTION
When `collect()` is used within `restart.redistribute()`, `t_array` will not be present (because it is not saved in restart files). In this case, just set `nt=1` because there is no time dimension.

Bug was introduced in #40 (I think).