### PR TITLE
Make boutdata/scripts/bout_squashoutput.py executable

### DIFF
--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -91,3 +91,7 @@ def main():
         args.__dict__[ind + "ind"] = slice(*args.__dict__[ind + "ind"])
     # Call the function, using command line arguments
     squash.squashoutput(**args.__dict__)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Can be useful when boutdata is not installed as a package, so the setuptools entry point is not available.