### PR TITLE
(Re-)add a dimensions attribute to BoutOutputs

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -1215,6 +1215,11 @@ class BoutOutputs(object):
         """Return a list of available variable names"""
         return self.grid_info["varNames"]
 
+    @property
+    def dimensions(self):
+        """Accesss a dict of dimensions of the variables"""
+        return self.grid_info["dimensions"]
+
     def evolvingVariables(self):
         """Return a list of names of time-evolving variables"""
         return self.grid_info["evolvingVariableNames"]


### PR DESCRIPTION
The dict of dimensions of variables was moved into `grid_info`, but `BoutOutputs.dimensions` was being used in `squashoutput()`, and is easier to find than a thing in `grid_info`, so makes sense to have it as a `@property`.