### PR TITLE
Option to split output in time into several files

### DIFF
--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -88,7 +88,7 @@ def main():
         default=None,
         help="By default no splitting is done. If an integer value is passed, the "
         "output is split into files with length in the t-dimension equal to that "
-        "value.  The outputs are labelled by prefacing a counter (starting by default "
+        "value. The outputs are labelled by prefacing a counter (starting by default "
         "at 0, but see time_split_first_label) to the file name before the .nc suffix.",
     )
     parser.add_argument(

--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -98,6 +98,13 @@ def main():
         help="Value at which to start the counter labelling output files when "
         "time_split_size is used.",
     )
+    parser.add_argument(
+        "--disable_parallel_write",
+        action="store_true",
+        default=False,
+        help="Parallel writing may increase memory usage, so it can be disabled even "
+        "when reading in parallel by setting passing this flag.",
+    )
 
     if argcomplete:
         argcomplete.autocomplete(parser)

--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -81,6 +81,23 @@ def main():
         help="Read data in parallel. Value is the number of processes to use, pass 0 "
         "to use as many as there are physical cores.",
     )
+    parser.add_argument(
+        "-t",
+        "--time_split_size",
+        type=int,
+        default=None,
+        help="By default no splitting is done. If an integer value is passed, the "
+        "output is split into files with length in the t-dimension equal to that "
+        "value.  The outputs are labelled by prefacing a counter (starting by default "
+        "at 0, but see time_split_first_label) to the file name before the .nc suffix.",
+    )
+    parser.add_argument(
+        "--time_split_first_label",
+        type=int,
+        default=0,
+        help="Value at which to start the counter labelling output files when "
+        "time_split_size is used.",
+    )
 
     if argcomplete:
         argcomplete.autocomplete(parser)

--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -98,13 +98,6 @@ def main():
         help="Value at which to start the counter labelling output files when "
         "time_split_size is used.",
     )
-    parser.add_argument(
-        "--disable_parallel_write",
-        action="store_true",
-        default=False,
-        help="Parallel writing may increase memory usage, so it can be disabled even "
-        "when reading in parallel by setting passing this flag.",
-    )
 
     if argcomplete:
         argcomplete.autocomplete(parser)

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -32,6 +32,7 @@ def squashoutput(
     parallel=False,
     time_split_size=None,
     time_split_first_label=0,
+    disable_parallel_write=False,
 ):
     """
     Collect all data from BOUT.dmp.* files and create a single output file.
@@ -99,6 +100,9 @@ def squashoutput(
     time_split_first_label : int, default 0
         Value at which to start the counter labelling output files when time_split_size
         is used.
+    disable_parallel_write : bool, default False
+        Parallel writing may increase memory usage, so it can be disabled even when
+        reading in parallel by setting this argument to True.
     """
     from boutdata.data import BoutOutputs
     from boututils.datafile import DataFile
@@ -185,10 +189,11 @@ def squashoutput(
                     "For some reason t_array has some duplicated entries in the new "
                     "and old file."
                 )
+    kwargs["format"] = format
 
     # Create file(s) for output and write data
     if time_split_size is None:
-        files = [DataFile(fullpath, create=True, write=True, format=format, **kwargs)]
+        files = [DataFile(fullpath, create=True, write=True, **kwargs)]
         tslices = [slice(None)]
     else:
         tind = outputs.tind
@@ -197,16 +202,18 @@ def squashoutput(
         # number accounting for the step.
         nt = (tind.stop + 1 - tind.start + tind.step - 1) // tind.step
         n_outputs = (nt + time_split_size - 1) // time_split_size
-        files = []
+        filenames = []
         t_slices = []
         for i in range(n_outputs):
             parts = fullpath.split(".")
             parts[-2] += str(time_split_first_label + i)
             filename = ".".join(parts)
-            files.append(
-                DataFile(filename, create=True, write=True, format=format, **kwargs)
-            )
+            filenames.append(filename)
             t_slices.append(slice(i * time_split_size, (i + 1) * time_split_size))
+
+    workers = SquashWorkers(
+        False if disable_parallel_write else parallel, filenames, kwargs
+    )
 
     for varname in outputvars:
         if not quiet:
@@ -224,20 +231,15 @@ def squashoutput(
             if not isinstance(var, int):
                 var = BoutArray(numpy.float32(var), var.attributes)
 
-        for f, t_slice in zip(files, t_slices):
-            if "t" in dims:
-                f.write(varname, var[t_slice])
-            else:
-                f.write(varname, var)
-            # Write changes, free memory
-            f.sync()
+        if "t" in dims:
+            workers.write_data(varname, [var[t_slice] for t_slice in t_slices])
+        else:
+            workers.write_data(varname, [var])
 
         var = None
         gc.collect()
 
-    for f in files:
-        f.close()
-
+    del workers
     del outputs
     gc.collect()
 
@@ -256,3 +258,180 @@ def squashoutput(
         # Note that get_chunk_cache() returns a tuple, so we have to unpack it when
         # passing to set_chunk_cache.
         set_chunk_cache(*netcdf4_chunk_cache)
+
+
+class SquashWorkers:
+    """
+    Class for packaging up worker processes for parallel writes, or passing the write
+    through in serial if parallel functionality not requested
+
+    Parameters
+    ----------
+    parallel : bool or int, default False
+        If False, write in serial. If True or 0 use all available processes. If positive
+        integer, use that many processes.
+    filenames : list of str
+        Names of the files to write to.
+    kwargs : dict
+        Keyword arguments to pass to DataFile constructors
+    """
+
+    def __init__(self, parallel, filenames, kwargs):
+        self.parallel = parallel
+        self.kwargs = kwargs
+        if self.parallel is False or len(filenames) == 1:
+            # No point doing parallel writing if there is only one output file
+            self.parallel = False
+            self.open_files(filenames)
+            return
+
+        if self.parallel is True or self.parallel == 0:
+            from boututils.run_wrapper import determineNumberOfCPUs
+
+            self.parallel = determineNumberOfCPUs()
+
+        self.n_outputs = len(filenames)
+
+        self.create_workers(filenames)
+
+    def __del__(self):
+        if self.parallel is False:
+            for f in self.files:
+                f.close()
+                del f
+        else:
+            for worker, connection, _ in self.workers:
+                # Send None to terminate worker process cleanly
+                connection.send(None)
+                worker.join()
+                connection.close()
+
+    def open_files(self, filenames):
+        """
+        Open files for serial writing
+
+        Parameters
+        ----------
+        filenames : list of str
+            Names of the files to write to.
+        """
+        from boututils.datafile import DataFile
+
+        self.files = [
+            DataFile(name, create=True, write=True, **self.kwargs) for name in filenames
+        ]
+
+    def create_workers(self, filenames):
+        """
+        Create workers for parallel writing
+
+        Parameters
+        ----------
+        filenames : list of str
+            Names of the files to write to.
+        """
+        from multiprocessing import Process, Pipe
+
+        n = min(self.parallel, self.n_outputs)
+        files_per_proc = [self.n_outputs // n for _ in range(n)]
+        for i in range(self.n_outputs % n):
+            files_per_proc[i] += 1
+        assert sum(files_per_proc) == self.n_outputs
+        counter = 0
+        self.workers = []
+        for i in range(n):
+            files_dict = {}
+            worker_indexes = range(counter, counter + files_per_proc[i])
+            for index in worker_indexes:
+                files_dict[index] = filenames[counter]
+                counter = counter + 1
+            parent_connection, child_connection = Pipe()
+            worker = Process(
+                target=self.worker_function,
+                args=(child_connection, files_dict),
+            )
+            worker.start()
+            self.workers.append((worker, parent_connection, worker_indexes))
+
+    def worker_function(self, connection, files_dict):
+        """
+        Function controlling execution on worker processes
+        """
+        from boututils.datafile import DataFile
+        from boututils.boutarray import BoutArray
+
+        output_files = {}
+        for i, name in files_dict.items():
+            output_files[i] = DataFile(name, create=True, write=True, **self.kwargs)
+
+        while True:
+            args = connection.recv()
+            if args is None:
+                # Terminate process cleanly
+                for f in files_dict.values():
+                    f.close()
+                connection.close()
+                return 0
+
+            varname, data, attributes = args
+
+            if not isinstance(data, dict):
+                # Time-independent variable or only one output file - write to all files
+                data = BoutArray(data, attributes=attributes)
+                for f in output_files.values():
+                    f.write(varname, data)
+                    # Write changes, free memory
+                    f.sync()
+            else:
+                # Time-dependent variable, write each slice to a separate file
+                for i, array in data.items():
+                    array = BoutArray(array, attributes=attributes)
+                    output_files[i].write(varname, array)
+                    # Write changes, free memory
+                    output_files[i].sync()
+
+    def write_data(self, varname, data_list):
+        """
+        Write data to the output files
+
+        Parameters
+        ----------
+        varname : str
+            Name of the variable being written.
+        data_list : list of BoutArray
+            Data to be written, either a single entry for a time-independent variable,
+            or self.n_outputs arrays giving all the time slices of a time-dependent
+            variable.
+        """
+        if self.parallel is False:
+            if len(data_list) == 1:
+                # Time-independent variable or only one output file - write to all files
+                for f in self.files:
+                    f.write(varname, data_list[0])
+                    # Write changes, free memory
+                    f.sync()
+            else:
+                # Time-dependent variable, write each slice to a separate file
+                for i, f in enumerate(self.files):
+                    f.write(varname, data_list[i])
+                    # Write changes, free memory
+                    f.sync()
+            return
+
+        # Note, need to pass attributes separately because apparently pickling (which
+        # happens to the data arrays when they are sent) converts BoutArrays to numpy
+        # arrays, losing the attributes.
+        if len(data_list) == 1:
+            # Time-independent variable or only one output file - write to all files
+            for _, connection, _ in self.workers:
+                connection.send((varname, data_list[0], data_list[0].attributes))
+        else:
+            # Time-dependent variable, write each slice to a separate file
+            for _, connection, worker_indexes in self.workers:
+                connection.send(
+                    (
+                        varname,
+                        {i: data_list[i] for i in worker_indexes},
+                        data_list[0].attributes,
+                    )
+                )

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -129,6 +129,8 @@ def squashoutput(
     fullpath = os.path.join(datadir, outputname)
 
     if append:
+        if time_split_size is not None:
+            raise ValueError("'time_split_size' is not compatible with append=True")
         datadirnew = tempfile.mkdtemp(dir=datadir)
         for f in glob.glob(os.path.join(datadir, "BOUT.dmp.*.??")):
             if not quiet:
@@ -175,8 +177,6 @@ def squashoutput(
         if complevel is not None:
             kwargs["complevel"] = complevel
     if append:
-        if time_split_size is not None:
-            raise ValueError("'time_split_size' is not compatible with append=True")
         old = DataFile(oldfile)
         # Check if dump on restart was enabled
         # If so, we want to drop the duplicated entry

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -396,6 +396,13 @@ class SquashWorkers:
         from boututils.datafile import DataFile
         from boututils.boutarray import BoutArray
 
+        try:
+            # Ensure chunk cache is not used on worker processes
+            from netCDF4 import set_chunk_cache
+            set_chunk_cache(0)
+        except ImportError:
+            pass
+
         output_files = {}
         for i, name in files_dict.items():
             output_files[i] = DataFile(name, create=True, write=True, **self.kwargs)

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -279,10 +279,10 @@ def _get_filenames_t_slices(time_split_size, time_split_first_label, fullpath, t
     if time_split_size is None:
         return [fullpath], [slice(None)]
     else:
-        # tind.stop + 1 - tind.start is the total number of t-indices ignoring the step.
+        # tind.stop - tind.start is the total number of t-indices ignoring the step.
         # Adding tind.step - 1 and integer-dividing by tind.step converts to the total
         # number accounting for the step.
-        nt = (tind.stop + 1 - tind.start + tind.step - 1) // tind.step
+        nt = (tind.stop - tind.start + tind.step - 1) // tind.step
         n_outputs = (nt + time_split_size - 1) // time_split_size
         filenames = []
         t_slices = []

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -104,6 +104,7 @@ def squashoutput(
         Parallel writing may increase memory usage, so it can be disabled even when
         reading in parallel by setting this argument to True.
     """
+    # use local imports to allow fast import for tab-completion
     from boutdata.data import BoutOutputs
     from boututils.datafile import DataFile
     from boututils.boutarray import BoutArray
@@ -315,6 +316,7 @@ class SquashWorkers:
         filenames : list of str
             Names of the files to write to.
         """
+        # use local imports to allow fast import for tab-completion
         from boututils.datafile import DataFile
 
         self.files = [
@@ -371,7 +373,7 @@ class SquashWorkers:
                 for f in files_dict.values():
                     f.close()
                 connection.close()
-                return 0
+                return
 
             varname, data, attributes = args
 

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -130,7 +130,7 @@ def squashoutput(
 
     if append:
         datadirnew = tempfile.mkdtemp(dir=datadir)
-        for f in glob.glob(datadir + "/BOUT.dmp.*.??"):
+        for f in glob.glob(os.path.join(datadir, "BOUT.dmp.*.??")):
             if not quiet:
                 print("moving", f, flush=True)
             shutil.move(f, datadirnew)

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -193,8 +193,8 @@ def squashoutput(
 
     # Create file(s) for output and write data
     if time_split_size is None:
-        files = [DataFile(fullpath, create=True, write=True, **kwargs)]
-        tslices = [slice(None)]
+        filenames = [fullpath]
+        t_slices = [slice(None)]
     else:
         tind = outputs.tind
         # tind.stop + 1 - tind.start is the total number of t-indices ignoring the step.

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -404,7 +404,7 @@ class SquashWorkers:
             args = connection.recv()
             if args is None:
                 # Terminate process cleanly
-                for f in files_dict.values():
+                for f in output_files.values():
                     f.close()
                 connection.close()
                 return

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -261,22 +261,6 @@ class TestCollect:
         # files created when setting time_split_size
         ######################################################################
 
-        doublenull = False
-
-        # Apply effect of arguments to expected data
-        if not collect_kwargs["xguards"]:
-            remove_xboundaries(expected, expected["MXG"])
-        if collect_kwargs["yguards"] is True and doublenull:
-            remove_yboundaries_upper_divertor(
-                expected, expected["MYG"], expected["ny_inner"]
-            )
-        if not collect_kwargs["yguards"]:
-            remove_yboundaries(
-                expected, expected["MYG"], expected["ny_inner"], doublenull
-            )
-
-        collect_kwargs = collect_kwargs.copy()
-
         # Always squash
         squashoutput(
             tmp_path, outputname="boutdata.nc", **collect_kwargs, **squash_kwargs
@@ -286,14 +270,6 @@ class TestCollect:
         dump_names = glob(str(tmp_path.joinpath("BOUT.dmp.*.nc")))
         for x in dump_names:
             Path(x).unlink()
-        # Reset arguments that are taken care of by squashoutput
-        for x in ("tind", "xind", "yind", "zind"):
-            if x in collect_kwargs:
-                collect_kwargs.pop(x)
-        # Never remove x-boundaries when collecting from a squashed file without them
-        collect_kwargs["xguards"] = True
-        # Never remove y-boundaries when collecting from a squashed file without them
-        collect_kwargs["yguards"] = "include_upper"
 
         # Assumes 'nt' is always 6, as set by make_grid_info() and create_dump_file()
         n_output = (6 + time_split[0] - 1) // time_split[0]

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -268,9 +268,8 @@ class TestCollect:
 
             with pytest.raises(
                 ValueError,
-                match=r"already exists, squashoutput\(\) will not overwrite.  Also, "
-                r"for some filenames collect may try to read from this file, which is "
-                r"presumably not desired behaviour.",
+                match=r" will not overwrite. Also, for some filenames collect may try "
+                r"to read from this file, which is presumably not desired behaviour.",
             ):
                 squashoutput(tmp_path, outputname="boutdata.nc", **squash_kwargs)
 

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -312,7 +312,6 @@ class TestCollect:
         grid_info = make_grid_info()
 
         fieldperp_global_yind = 3
-        fieldperp_yproc_ind = 0
 
         rng = np.random.default_rng(100)
 
@@ -322,22 +321,15 @@ class TestCollect:
         dump_params = [
             (0, ["xinner", "xouter", "ylower", "yupper"], fieldperp_global_yind),
         ]
-        dumps = []
         for i, boundaries, fieldperp_yind in dump_params:
-            dumps.append(
-                create_dump_file(
-                    tmpdir=tmp_path,
-                    rng=rng,
-                    grid_info=grid_info,
-                    i=i,
-                    boundaries=boundaries,
-                    fieldperp_global_yind=fieldperp_yind,
-                )
+            create_dump_file(
+                tmpdir=tmp_path,
+                rng=rng,
+                grid_info=grid_info,
+                i=i,
+                boundaries=boundaries,
+                fieldperp_global_yind=fieldperp_yind,
             )
-
-        expected = concatenate_data(
-            dumps, nxpe=grid_info["NXPE"], fieldperp_yproc_ind=fieldperp_yproc_ind
-        )
 
         with pytest.raises(
             ValueError, match="'time_split_size' is not compatible with append=True"


### PR DESCRIPTION
Adds an option `time_split_size` for `squashoutput()` that can be used to split the output of `squashoutput` into several files, each with a size in the time-dimension of `time_split_size` (except the last file, which may be smaller when the length of the time dimension is not a multiple of `time_split_size`). The several output files are labelled consecutively by a counter - a second option `time_split_first_label` can be used to set the first label to a non-zero value for convenience.

~~When `squashoutput` is writing output to multiple files, the writing is parallelised if the `parallel` argument is set to a non-`False` value. Parallel writing may increase the memory usage, so it can be disabled (while keeping parallel reading) by passing `disable_parallel_write=True`.~~

Includes tests of ~~both~~ output splitting ~~and parallel writing~~.