### PR TITLE
Add restart.change_grid function

### DIFF
--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1015,6 +1015,7 @@ def change_grid(
         raise ValueError("ERROR: No restart files found")
 
     copy_vars = [
+        "BOUT_VERSION",
         "NXPE",
         "NYPE",
         "hist_hi",
@@ -1023,6 +1024,7 @@ def change_grid(
         "MYG",
         "MZG",
         "nz",
+        "MZ",
         "run_id",
         "run_restart_from",
     ]
@@ -1161,10 +1163,11 @@ def change_grid(
         iy = i // nxpe
 
         def get_block(data):
-            return data[
+            sliced = data[
                 ix * mxsub : (ix + 1) * mxsub + 2 * mxg,
                 iy * mysub : (iy + 1) * mysub + 2 * myg,
             ]
+            return sliced.reshape(sliced.shape + (1,)) # make 3D
 
         outpath = os.path.join(output, "BOUT.restart." + str(i) + ".nc")
         with DataFile(outpath, create=True) as f:

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1156,6 +1156,9 @@ def change_grid(
         with DataFile(outpath, create=True) as f:
             print("Creating " + outpath)
 
+            f.write("PE_XIND", ix)
+            f.write("PE_YIND", iy)
+
             # Write the scalars
             for k in copy_data:
                 f.write(k, copy_data[k])

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -994,9 +994,11 @@ def change_grid(
         # Check for y boundary cells
         try:
             if g["y_boundary_guards"] != 0:
-                raise ValueError("Support for grid files with y-boundary cells not implemented yet")
+                raise ValueError(
+                    "Support for grid files with y-boundary cells not implemented yet"
+                )
         except KeyError:
-            pass # No y_boundary_guards key
+            pass  # No y_boundary_guards key
         from_Rxy = g["Rxy"]
         from_Zxy = g["Zxy"]
 
@@ -1004,9 +1006,11 @@ def change_grid(
         # Check for y boundary cells
         try:
             if g["y_boundary_guards"] != 0:
-                raise ValueError("Support for grid files with y-boundary cells not implemented yet")
+                raise ValueError(
+                    "Support for grid files with y-boundary cells not implemented yet"
+                )
         except KeyError:
-            pass # No y_boundary_guards key
+            pass  # No y_boundary_guards key
         to_Rxy = g["Rxy"]
         to_Zxy = g["Zxy"]
 
@@ -1167,7 +1171,7 @@ def change_grid(
                 ix * mxsub : (ix + 1) * mxsub + 2 * mxg,
                 iy * mysub : (iy + 1) * mysub + 2 * myg,
             ]
-            return sliced.reshape(sliced.shape + (1,)) # make 3D
+            return sliced.reshape(sliced.shape + (1,))  # make 3D
 
         outpath = os.path.join(output, "BOUT.restart." + str(i) + ".nc")
         with DataFile(outpath, create=True) as f:

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1131,7 +1131,7 @@ def change_grid(
         # Can't split grid in this way
         raise ValueError("nxpe={} not compatible with nx = {}".format(nxpe, new_nx))
     if (new_ny - 2 * myg) % nxpe != 0:
-        # Can't split grid in this waymxsub = (new_nx - 2*mxg) // nxpe
+        # Can't split grid in this way
         raise ValueError("nype={} not compatible with ny = {}".format(nype, new_ny))
 
     mxsub = (new_nx - 2 * mxg) // nxpe

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1026,7 +1026,7 @@ def change_grid(
         for var in varnames:
             dimensions = f.dimensions(var)
             if dimensions == ("x", "y", "z"):
-                # Could be an evolving variable [x,y,z]x
+                # Could be an evolving variable [x,y,z]
                 interp_vars.append(var)
 
     # Only tested for nz = 1

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -971,6 +971,7 @@ def change_grid(
 
     Notes:
     - Only working for 2D (axisymmetric) simulations with nz = 1
+    - Does not support evolving Field2D or FieldPerp variables
 
     from_grid_file : str
          File containing the input grid

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1145,7 +1145,7 @@ def change_grid(
 
     for i in range(npes):
         ix = i % nxpe
-        iy = int(i / nxpe)
+        iy = i // nxpe
 
         def get_block(data):
             return data[

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -972,6 +972,7 @@ def change_grid(
     Notes:
     - Only working for 2D (axisymmetric) simulations with nz = 1
     - Does not support evolving Field2D or FieldPerp variables
+    - Does not support grids with y boundary cells
 
     from_grid_file : str
          File containing the input grid
@@ -990,10 +991,22 @@ def change_grid(
 
     # Read in grid files
     with DataFile(from_grid_file) as g:
+        # Check for y boundary cells
+        try:
+            if g["y_boundary_guards"] != 0:
+                raise ValueError("Support for grid files with y-boundary cells not implemented yet")
+        except KeyError:
+            pass # No y_boundary_guards key
         from_Rxy = g["Rxy"]
         from_Zxy = g["Zxy"]
 
     with DataFile(to_grid_file) as g:
+        # Check for y boundary cells
+        try:
+            if g["y_boundary_guards"] != 0:
+                raise ValueError("Support for grid files with y-boundary cells not implemented yet")
+        except KeyError:
+            pass # No y_boundary_guards key
         to_Rxy = g["Rxy"]
         to_Zxy = g["Zxy"]
 


### PR DESCRIPTION
Converts restart files from one input grid to another, by interpolating in the R-Z plane. Intended for doing resolution scans with axisymmetric simulations.

Only works for nz=1 for now, as testing for axisymmetric simulations.
Asserts that nz=1, and could be extended in future, perhaps by interpolating one Z slice at a time.