### PR TITLE
Fix restart.redistribute(): better default handling for mxg, myg in get_processor_layout()

### DIFF
--- a/boutdata/processor_rearrange.py
+++ b/boutdata/processor_rearrange.py
@@ -56,16 +56,8 @@ def get_processor_layout(boutfile, has_t_dimension=True, mxg=None, myg=None):
 
     """
 
-    if mxg is None:
-        try:
-            mxg = boutfile["MXG"]
-        except KeyError:
-            mxg = 2
-    if myg is None:
-        try:
-            myg = boutfile["MYG"]
-        except KeyError:
-            myg = 2
+    mxg = mxg or boutfile.get("MXG", 2)
+    myg = myg or boutfile.get("MYG", 2)
 
     nxpe = boutfile.read("NXPE")
     nype = boutfile.read("NYPE")

--- a/boutdata/processor_rearrange.py
+++ b/boutdata/processor_rearrange.py
@@ -36,7 +36,7 @@ class processor_layout(processor_layout_):
     pass
 
 
-def get_processor_layout(boutfile, has_t_dimension=True, mxg=2, myg=2):
+def get_processor_layout(boutfile, has_t_dimension=True, mxg=None, myg=None):
     """Given a BOUT.restart.* or BOUT.dmp.* file (as a DataFile object),
     return the processor layout for its data
 
@@ -55,6 +55,17 @@ def get_processor_layout(boutfile, has_t_dimension=True, mxg=2, myg=2):
         A description of the processor layout and grid sizes
 
     """
+
+    if mxg is None:
+        try:
+            mxg = boutfile["MXG"]
+        except KeyError:
+            mxg = 2
+    if myg is None:
+        try:
+            myg = boutfile["MYG"]
+        except KeyError:
+            myg = 2
 
     nxpe = boutfile.read("NXPE")
     nype = boutfile.read("NYPE")


### PR DESCRIPTION
When `mxg` or `myg` are not given explicitly as arguments to `processor_rearrange.get_processor_layout()`, try to read them from the `boutfile`, and only set to hard-coded value of `2` if they are not present in `boutfile`.

Fixes a bug with `restart.redistribute()` where if the input restart files had `mxg != 2` or `myg != 2` the output restart files would be
wrong.