### PR TITLE
Copy file attributes in squashoutput()

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -1151,6 +1151,8 @@ class BoutOutputs(object):
                 connection.send(None)
                 worker.join()
                 connection.close()
+        if self._file0 is not None:
+            self._file0.close()
 
     def _init_caching(self):
         """

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -226,6 +226,12 @@ def squashoutput(
         var = None
         gc.collect()
 
+    # Copy file attributes
+    for attrname in outputs.list_file_attributes():
+        attrval = outputs.get_file_attribute(attrname)
+        for f in files:
+            f.write_file_attribute(attrname, attrval)
+
     for f in files:
         f.close()
 

--- a/boutdata/tests/make_test_data.py
+++ b/boutdata/tests/make_test_data.py
@@ -75,6 +75,12 @@ expected_attributes = {
     },
 }
 
+expected_file_attributes = {
+    "global_str_attribute": "foobar",
+    "global_int_attribute": 42,
+    "global_float_attribute": 7.0,
+}
+
 
 def make_grid_info(
     *, mxg=2, myg=2, nxpe=1, nype=1, ixseps1=None, ixseps2=None, xpoints=0
@@ -320,6 +326,9 @@ def create_dump_file(*, i, tmpdir, rng, grid_info, boundaries, fieldperp_global_
         createScalar("PE_XIND", i % nxpe)
         createScalar("PE_YIND", i // nxpe)
         createScalar("MYPE", i)
+
+        for attrname, attr in expected_file_attributes.items():
+            setattr(outputfile, attrname, attr)
 
     return result
 

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -6,12 +6,14 @@ import pytest
 
 from boutdata.collect import collect
 from boutdata.squashoutput import squashoutput
+from boututils.datafile import DataFile
 
 from boutdata.tests.make_test_data import (
     apply_slices,
     create_dump_file,
     concatenate_data,
     expected_attributes,
+    expected_file_attributes,
     make_grid_info,
     remove_xboundaries,
     remove_yboundaries,
@@ -57,7 +59,7 @@ def check_collected_data(
         Arrays should be global (not per-process).
     fieldperp_global_yind : int
         Global y-index where FieldPerps are expected to be defined.
-    path : pathlib.Path or str
+    path : pathlib.Path
         Path to collect data from.
     squash : bool
         If True, call `squashoutput()` and delete the `BOUT.dmp.*.nc` files (so that we
@@ -103,6 +105,14 @@ def check_collected_data(
             expected_attributes.get(varname, None),
             fieldperp_global_yind,
         )
+
+    if squash:
+        filename = path.joinpath("boutdata.nc")
+    else:
+        filename = path.joinpath("BOUT.dmp.0.nc")
+    with DataFile(str(filename)) as f:
+        for attrname, attr in expected_file_attributes.items():
+            assert f.read_file_attribute(attrname) == attr
 
 
 def check_variable(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
         "numpy",
         "matplotlib",
         "scipy",
-        "boututils",
+        "boututils>=0.1.9",
         "importlib-metadata ; python_version<'3.8'",
     ],
     classifiers=[


### PR DESCRIPTION
Ensure any file attributes are copied across when using `squashoutput()`. Previously any file attributes on the input dump files would be ignored, and therefore missing from the squashed files, which could result in important metadata being lost.

Adds methods to `BoutOutputs` to get a file attribute, and to list all file attributes.

Note: `BoutOutputs` gets/lists the file attributes from `BOUT.dmp.0.nc`, making no attempt to check that file attributes are consistent between all dump files.

Need to make a `boututils` release including https://github.com/boutproject/boututils/pull/40 before the tests will pass here.