### PR TITLE
Add restart.shift_v3_to_v4()

### DIFF
--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -1197,7 +1197,9 @@ def change_grid(
                 f.write(k, get_block(interp_data[k]))
 
 
-def shift_v3_to_v4(gridfile, zperiod, path="data", output=".", informat="nc", mxg=2, myg=2):
+def shift_v3_to_v4(
+    gridfile, zperiod, path="data", output=".", informat="nc", mxg=2, myg=2
+):
     """Convert a set of restart files from BOUT++ v3 to v4
 
        Assumes that both simulations are using shifted metric coordinates:
@@ -1266,8 +1268,14 @@ def shift_v3_to_v4(gridfile, zperiod, path="data", output=".", informat="nc", mx
             new.write("MXG", mxg)
             new.write("MYG", myg)
             new.write("MZG", 0)
-            new.write("run_id", np.array(list('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'), dtype='c'))
-            new.write("run_restart_from", np.array(list('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'), dtype='c'))
+            new.write(
+                "run_id",
+                np.array(list("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), dtype="c"),
+            )
+            new.write(
+                "run_restart_from",
+                np.array(list("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), dtype="c"),
+            )
 
             # Loop over the variables in the old file
             for var in old.list():
@@ -1292,13 +1300,15 @@ def shift_v3_to_v4(gridfile, zperiod, path="data", output=".", informat="nc", mx
 
                     # Shifting by zShift goes from field-aligned to orthogonal coords
                     # Note: Removing y guards but not X because zShift includes x boundaries
-                    newdata[:, myg:-myg, :] = shiftz.shiftz(newdata[:, myg:-myg, :],
-                                                            zShift[x_offset:(x_offset + nx),
-                                                                   y_offset:(y_offset + MYSUB)],
-                                                            zperiod=zperiod)
+                    newdata[:, myg:-myg, :] = shiftz.shiftz(
+                        newdata[:, myg:-myg, :],
+                        zShift[
+                            x_offset : (x_offset + nx), y_offset : (y_offset + MYSUB)
+                        ],
+                        zperiod=zperiod,
+                    )
                     new.write("nx", nx)
                     new.write("ny", ny - 2 * myg)
                     new.write("nz", nz)
                 newdata = BoutArray(newdata, attributes=attributes)
                 new.write(var, newdata)
-

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -17,6 +17,7 @@ from boututils.boutarray import BoutArray
 from boutdata.processor_rearrange import get_processor_layout, create_processor_layout
 
 import multiprocessing
+from natsort import natsorted
 import numpy as np
 from numpy import mean, zeros, arange
 from numpy.random import normal
@@ -1238,7 +1239,7 @@ def shift_v3_to_v4(
         raise ValueError("Can't overwrite restart file")
 
     file_list = glob.glob(os.path.join(path, "BOUT.restart.*." + informat))
-    file_list.sort()
+    file_list = natsorted(file_list)
     nfiles = len(file_list)
 
     if nfiles == 0:

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -23,6 +23,8 @@ from numpy.random import normal
 
 from scipy.interpolate import interp1d
 
+from boutdata import shiftz
+
 try:
     from scipy.interpolate import RegularGridInterpolator
 except ImportError:
@@ -294,16 +296,14 @@ def resizeZ(newNz, path="data", output="./", informat="nc", outformat=None):
         outformat = informat
 
     if path == output:
-        print("ERROR: Can't overwrite restart files when expanding")
-        return False
+        raise ValueError("Can't overwrite restart files when expanding")
 
     file_list = glob.glob(os.path.join(path, "BOUT.restart.*." + informat))
     file_list.sort()
     nfiles = len(file_list)
 
     if nfiles == 0:
-        print("ERROR: No data found")
-        return False
+        raise ValueError("No data found")
 
     print("Number of files found: " + str(nfiles))
 
@@ -1195,3 +1195,110 @@ def change_grid(
             # Write fields
             for k in interp_data:
                 f.write(k, get_block(interp_data[k]))
+
+
+def shift_v3_to_v4(gridfile, zperiod, path="data", output=".", informat="nc", mxg=2, myg=2):
+    """Convert a set of restart files from BOUT++ v3 to v4
+
+       Assumes that both simulations are using shifted metric coordinates:
+       - v3 restarts are in field-aligned coordinates
+         (shifted when taking X derivatives)
+       - v4 restarts are in shifted coordinates
+         (shifted when taking Y derivatives)
+
+    Parameters
+    ----------
+
+    gridfile : str
+        String containing grid file name
+    zperiod : int
+        Number of times the domain is repeated to form a full torus
+    path : str, optional
+        Directory containing the input restart files (BOUT++ v3)
+    output : str, optional
+        Directory where the output restart files will go
+    informat : str, optional
+        File extension of the input restart files
+    mxg : int, optional
+        Number of X guard cells
+    myg : int, optional
+        Number of Y guard cells
+    """
+
+    # Try opening the grid file
+    with DataFile(gridfile) as grid:
+        try:
+            zShift = grid["zShift"]
+        except KeyError:
+            zShift = grid["qinty"]
+
+    if path == output:
+        raise ValueError("Can't overwrite restart file")
+
+    file_list = glob.glob(os.path.join(path, "BOUT.restart.*." + informat))
+    file_list.sort()
+    nfiles = len(file_list)
+
+    if nfiles == 0:
+        raise ValueError("No data found")
+
+    print("Number of files found: " + str(nfiles))
+
+    # Read processor layout
+    with DataFile(file_list[0]) as f:
+        NXPE = f["NXPE"]
+        NPES = f["NPES"]
+    if NPES != nfiles:
+        raise ValueError("Number of restart files doesn't match NPES")
+
+    for n in range(nfiles):
+        basename = "BOUT.restart.{}.{}".format(n, informat)
+        f = os.path.join(path, basename)
+        new_f = os.path.join(output, basename)
+        print("Changing {} => {}".format(f, new_f))
+
+        pe_xind = n % NXPE
+        pe_yind = n // NXPE
+
+        # Open the restart file in read mode and create the new file
+        with DataFile(f) as old, DataFile(new_f, write=True, create=True) as new:
+            # Add new variables
+            new.write("MXG", mxg)
+            new.write("MYG", myg)
+            new.write("MZG", 0)
+            new.write("run_id", np.array(list('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'), dtype='c'))
+            new.write("run_restart_from", np.array(list('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'), dtype='c'))
+
+            # Loop over the variables in the old file
+            for var in old.list():
+                # Read the data
+                data = old.read(var)
+                attributes = old.attributes(var)
+
+                # Find 3D variables
+                newdata = data
+                if old.ndims(var) == 3:
+                    print("    Shifting " + var)
+
+                    # Remove one Z grid cell
+                    newdata = newdata[:, :, :-1]
+
+                    nx, ny, nz = newdata.shape
+                    MXSUB = nx - 2 * mxg
+                    MYSUB = ny - 2 * myg
+
+                    x_offset = pe_xind * MXSUB
+                    y_offset = pe_yind * MYSUB
+
+                    # Shifting by zShift goes from field-aligned to orthogonal coords
+                    # Note: Removing y guards but not X because zShift includes x boundaries
+                    newdata[:, myg:-myg, :] = shiftz.shiftz(newdata[:, myg:-myg, :],
+                                                            zShift[x_offset:(x_offset + nx),
+                                                                   y_offset:(y_offset + MYSUB)],
+                                                            zperiod=zperiod)
+                    new.write("nx", nx)
+                    new.write("ny", ny - 2 * myg)
+                    new.write("nz", nz)
+                newdata = BoutArray(newdata, attributes=attributes)
+                new.write(var, newdata)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ sympy==1.5.1
 numpy==1.21.0
 setuptools==46.1.3
 matplotlib==3.2.1
+natsort==8.1.0
 scipy==1.4.1
 setuptools_scm==5.0.1
 boututils

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
         "sympy",
         "numpy",
         "matplotlib",
+        "natsort",
         "scipy",
         "boututils>=0.1.9",
         "importlib-metadata ; python_version<'3.8'",


### PR DESCRIPTION
Converts a set of BOUT++ v3.1 restart files so they can be used to restart a simulation with BOUT++ v4 (next branch).