### PR TITLE
Multiline values

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -713,13 +713,23 @@ class BoutOptionsFile(BoutOptions):
                         # then continue reading
                         def count_brackets(s):
                             "Count net number of opening and closing brackets"
-                            return s.count('(') - s.count(')') + s.count('[') - s.count(']')
+                            return (
+                                s.count("(")
+                                - s.count(")")
+                                + s.count("[")
+                                - s.count("]")
+                            )
+
                         if count_brackets(value) != 0:
                             for cont_linenr, cont_line in nr_line_iter:
                                 # Check for comments on continuing lines
                                 comment_match = self.COMMENT_REGEX.search(cont_line)
                                 if comment_match is not None:
-                                    cont_line, comment_whitespace, cont_inline_comment = comment_match.groups()
+                                    (
+                                        cont_line,
+                                        comment_whitespace,
+                                        cont_inline_comment,
+                                    ) = comment_match.groups()
                                     # Append inline comments
                                     if inline_comment is not None:
                                         inline_comment += " " + cont_inline_comment[1:]


### PR DESCRIPTION
In BOUT++ `next` (not `master`) if input values contain unbalanced brackets or parentheses ('[]' or '()') then reading continues to the next line. This allows long expressions (or lists in Hermes-3) to be spread over multiple lines.

The corresponding code in BOUT++ is here: https://github.com/boutproject/BOUT-dev/blob/next/src/sys/options/options_ini.cxx#L132
Looking at this again, that line should probably be `while (count == 0)`

Fixes #73.