### PR TITLE
Save version when squashing

### DIFF
--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -10,6 +10,8 @@ and because single files are quicker to download.
 
 """
 
+from . import __version__
+
 
 def squashoutput(
     datadir=".",
@@ -35,6 +37,9 @@ def squashoutput(
 ):
     """
     Collect all data from BOUT.dmp.* files and create a single output file.
+
+    Note: adds an attribute to the 'squashed' output file called `squashoutput_version`
+    which records the current version number of `boutdata`.
 
     Parameters
     ----------
@@ -231,6 +236,8 @@ def squashoutput(
         attrval = outputs.get_file_attribute(attrname)
         for f in files:
             f.write_file_attribute(attrname, attrval)
+
+    f.write_file_attribute("squashoutput_version", __version__)
 
     for f in files:
         f.close()


### PR DESCRIPTION
When squashing data with `squashoutput()` (or the `bout-squashoutput` command line tool), record the version of `boutdata` being used as an attribute `squashoutput_version` of the output file. Might be useful if/when some bug in `squashoutput()`, etc., might affect the output file, to find out if it did or didn't.