### PR TITLE
Generation of grid points in boutdata.resize

### DIFF
--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -197,8 +197,8 @@ def resize(
             yCoordOld = np.arange(ny - myg + shift)*dy
             zCoordOld = np.arange(nz + shift)*dz
             # Calculate the new spacing
-            newDx= dx * ((nx - mxg) / (newNx - mxg) )
-            newDy= dy * ((ny - myg) / (newNy - myg) )
+            newDx= dx * ((nx - 2*mxg) / (newNx - 2*mxg) )
+            newDy= dy * ((ny - 2*myg) / (newNy - 2*myg) )
             newDz= dz * (nz / newNz )
             # Calculate the new coordinates
             xCoordNew = np.arange(newNx - mxg + shift)*newDx

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -186,24 +186,26 @@ def resize(
             nx, ny, nz = data.shape
             dx, dy, dz = old['dx'].flat[0], old['dy'].flat[0], old['dz'].flat[0]
             # shift grid if CELL-CENTRED   
-            shift = 0.5 if old.attributes(var)['cell_location'] == 'CELL-CENTRE' else 0
+            xshift = 0.0 if old.attributes(var)['cell_location'] == 'CELL_XLOW' else 0.5
+            yshift = 0.0 if old.attributes(var)['cell_location'] == 'CELL_YLOW' else 0.5
+            zshift = 0.0 if old.attributes(var)['cell_location'] == 'CELL_ZLOW' else 0.5
             
             # Make coordinates
             # NOTE: The max min of the coordinates are irrelevant when
             #       interpolating (as long as old and new coordinates
             #       are consistent), so we just choose all variable to
             #       be between 0 and 1 Calculate the old coordinates 
-            xCoordOld = np.arange(nx - mxg + shift)*dx
-            yCoordOld = np.arange(ny - myg + shift)*dy
-            zCoordOld = np.arange(nz + shift)*dz
+            xCoordOld = np.arange(nx - mxg + xshift)*dx
+            yCoordOld = np.arange(ny - myg + yshift)*dy
+            zCoordOld = np.arange(nz + zshift)*dz
             # Calculate the new spacing
             newDx= dx * ((nx - 2*mxg) / (newNx - 2*mxg) )
             newDy= dy * ((ny - 2*myg) / (newNy - 2*myg) )
             newDz= dz * (nz / newNz )
             # Calculate the new coordinates
-            xCoordNew = np.arange(newNx - mxg + shift)*newDx
-            yCoordNew = np.arange(newNy - myg + shift)*newDy
-            zCoordNew = np.arange(newNz + shift)*newDz
+            xCoordNew = np.arange(newNx - mxg + xshift)*newDx
+            yCoordNew = np.arange(newNy - myg + yshift)*newDy
+            zCoordNew = np.arange(newNz + zshift)*newDz
 
             # Make a pool of workers
             pool = multiprocessing.Pool(maxProc)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -69,7 +69,7 @@ def resize3DField(var, data, coordsAndSizesTuple, method, mute):
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html
     # for details)
     gridInterpolator = RegularGridInterpolator(
-        (xCoordOld, yCoordOld, zCoordOld), data, method, fill_value = 0.0
+        (xCoordOld, yCoordOld, zCoordOld), data, method, bounds_error = False, fill_value = None
     )
 
     # Need to fill with one exrta z plane (will only contain zeros)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -250,7 +250,7 @@ def resize(
                 else:
                     if not (mute):
                         print("    Copying " + var)
-                        newData = data.copy()
+                    newData = data.copy()
                     if not (mute):
                         print("Writing " + var)
                     new.write(var, newData)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -69,7 +69,7 @@ def resize3DField(var, data, coordsAndSizesTuple, method, mute):
     # https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html
     # for details)
     gridInterpolator = RegularGridInterpolator(
-        (xCoordOld, yCoordOld, zCoordOld), data, method
+        (xCoordOld, yCoordOld, zCoordOld), data, method, fill_value = 0.0
     )
 
     # Need to fill with one exrta z plane (will only contain zeros)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -186,7 +186,7 @@ def resize(
             nx, ny, nz = data.shape
             dx, dy, dz = old['dx'].flat[0], old['dy'].flat[0], old['dz'].flat[0]
             # shift grid if CELL-CENTRED   
-            shift = 0.5 if old.attributes(var) == 0 else 0
+            shift = 0.5 if old.attributes(var)['cell_location'] == 'CELL-CENTRE' else 0
             
             # Make coordinates
             # NOTE: The max min of the coordinates are irrelevant when

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -184,19 +184,26 @@ def resize(
                     break
 
             nx, ny, nz = data.shape
+            dx, dy, dz = old['dx'].flat[0], old['dy'].flat[0], old['dz'].flat[0]
+            # shift grid if CELL-CENTRED   
+            shift = 0.5 if old.attributes(var) == 0 else 0
+            
             # Make coordinates
             # NOTE: The max min of the coordinates are irrelevant when
             #       interpolating (as long as old and new coordinates
             #       are consistent), so we just choose all variable to
-            #       be between 0 and 1 Calculate the old coordinates
-            xCoordOld = np.linspace(0, 1, nx)
-            yCoordOld = np.linspace(0, 1, ny)
-            zCoordOld = np.linspace(0, 1, nz)
-
+            #       be between 0 and 1 Calculate the old coordinates 
+            xCoordOld = np.arange(nx - mxg + shift)*dx
+            yCoordOld = np.arange(ny - myg + shift)*dy
+            zCoordOld = np.arange(nz + shift)*dz
+            # Calculate the new spacing
+            newDx= dx * ((nx - mxg) / (newNx - mxg) )
+            newDy= dy * ((ny - myg) / (newNy - myg) )
+            newDz= dz * (nz / newNz )
             # Calculate the new coordinates
-            xCoordNew = np.linspace(xCoordOld[0], xCoordOld[-1], newNx)
-            yCoordNew = np.linspace(yCoordOld[0], yCoordOld[-1], newNy)
-            zCoordNew = np.linspace(zCoordOld[0], zCoordOld[-1], newNz)
+            xCoordNew = np.arange(newNx - mxg + shift)*newDx
+            yCoordNew = np.arange(newNy - myg + shift)*newDy
+            zCoordNew = np.arange(newNz + shift)*newDz
 
             # Make a pool of workers
             pool = multiprocessing.Pool(maxProc)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -195,17 +195,17 @@ def resize(
             #       interpolating (as long as old and new coordinates
             #       are consistent), so we just choose all variable to
             #       be between 0 and 1 Calculate the old coordinates 
-            xCoordOld = np.arange(nx - mxg + xshift)*dx
-            yCoordOld = np.arange(ny - myg + yshift)*dy
-            zCoordOld = np.arange(nz + zshift)*dz
+            xCoordOld = (np.arange(nx) - mxg + xshift)*dx
+            yCoordOld = (np.arange(ny) - myg + yshift)*dy
+            zCoordOld = (np.arange(nz) + zshift)*dz
             # Calculate the new spacing
             newDx= dx * ((nx - 2*mxg) / (newNx - 2*mxg) )
             newDy= dy * ((ny - 2*myg) / (newNy - 2*myg) )
             newDz= dz * (nz / newNz )
             # Calculate the new coordinates
-            xCoordNew = np.arange(newNx - mxg + xshift)*newDx
-            yCoordNew = np.arange(newNy - myg + yshift)*newDy
-            zCoordNew = np.arange(newNz + zshift)*newDz
+            xCoordNew = (np.arange(newNx) - mxg + xshift)*newDx
+            yCoordNew = (np.arange(newNy) - myg + yshift)*newDy
+            zCoordNew = (np.arange(newNz) + zshift)*newDz
 
             # Make a pool of workers
             pool = multiprocessing.Pool(maxProc)


### PR DESCRIPTION
This PR is in regards to the issue https://github.com/boutproject/boutdata/issues/78#issuecomment-1222448537

This patch resolves the issue of inconsistency when generating grid points for interpolation. One problem with the current implementation is that values at guard cells would end up inside the physical domain with the nearest neighbour algorithm when upsizing, i.e. increasing the resolution ]. 