### PR TITLE
`drop_variables` argument to `squashoutput()`

### DIFF
--- a/boutdata/scripts/bout_squashoutput.py
+++ b/boutdata/scripts/bout_squashoutput.py
@@ -63,6 +63,14 @@ def main():
     parser.add_argument("--xind", type=int_or_none, nargs="*", default=[None])
     parser.add_argument("--yind", type=int_or_none, nargs="*", default=[None])
     parser.add_argument("--zind", type=int_or_none, nargs="*", default=[None])
+    parser.add_argument(
+        "--drop_variables",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Variable names passed in drop_variables will be ignored, and not "
+        "included in the squashed output file.",
+    )
     parser.add_argument("-s", "--singleprecision", action="store_true", default=False)
     parser.add_argument("-c", "--compress", action="store_true", default=False)
     parser.add_argument("-l", "--complevel", type=int_or_none, default=None)

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -23,6 +23,7 @@ def squashoutput(
     zind=None,
     xguards=True,
     yguards="include_upper",
+    drop_variables=None,
     singleprecision=False,
     compress=False,
     least_significant_digit=None,
@@ -71,6 +72,9 @@ def squashoutput(
     yguards : bool or "include_upper"
         yguards argument passed to collect (note different default to collect's)
         default "include_upper"
+    drop_variables : str, or list or tuple of strings
+        Variable names passed in drop_variables will be ignored, and not included in the
+        squashed output file.
     singleprecision : bool
         If true convert data to single-precision floats
         default False
@@ -140,6 +144,11 @@ def squashoutput(
         oldfile = datadirnew + "/" + outputname
         datadir = datadirnew
 
+    if drop_variables is None:
+        drop_variables = []
+    elif isinstance(drop_variables, str):
+        drop_variables = [drop_variables]
+
     # useful object from BOUT pylib to access output data
     outputs = BoutOutputs(
         datadir,
@@ -168,7 +177,7 @@ def squashoutput(
                     "is presumably not desired behaviour.".format(fullpath)
                 )
 
-    outputvars = outputs.keys()
+    outputvars = [k for k in outputs.keys() if k not in drop_variables]
 
     # Read a value to cache the files
     outputs[outputvars[0]]

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -144,7 +144,7 @@ def squashoutput(
         oldfile = datadirnew + "/" + outputname
         datadir = datadirnew
 
-    if drop_variables is None:
+    if not drop_variables:
         drop_variables = []
     elif isinstance(drop_variables, str):
         drop_variables = [drop_variables]


### PR DESCRIPTION
Useful in case some variable causes problems due to being written in a non-standard way, or to reduce the output size by removing unneeded variables.

Fixes #82 (provides workaround at least).