### PR TITLE
Small fixes to restart utils

### DIFF
--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -482,7 +482,12 @@ def create(
         outfile = DataFile(outfname, create=True)
 
         # Get the data always needed in restart files
+        # hist_hi should be an integer in the restart files
         hist_hi = infile.read("iteration")
+        try:
+            hist_hi = hist_hi[final]
+        except:
+            pass
         print(("hist_hi = ", hist_hi))
         outfile.write("hist_hi", hist_hi)
 

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -153,14 +153,6 @@ def resize(
         print("ERROR: Can't overwrite restart files when expanding")
         return False
 
-    def is_pow2(x):
-        """Returns true if x is a power of 2"""
-        return (x > 0) and ((x & (x - 1)) == 0)
-
-    if not is_pow2(newNz):
-        print("ERROR: New Z size {} must be a power of 2".format(newNz))
-        return False
-
     file_list = glob.glob(os.path.join(path, "BOUT.restart.*." + informat))
     file_list.sort()
     nfiles = len(file_list)

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -484,10 +484,9 @@ def create(
         # Get the data always needed in restart files
         # hist_hi should be an integer in the restart files
         hist_hi = infile.read("iteration")
-        try:
+        if hasattr(hist_hi, "__getitem__"):
             hist_hi = hist_hi[final]
-        except:
-            pass
+
         print(("hist_hi = ", hist_hi))
         outfile.write("hist_hi", hist_hi)
 
@@ -518,13 +517,17 @@ def create(
                 data = infile.read(var)
 
                 if averagelast == 1:
-                    slice = data[final, :, :, :]
+                    data_slice = data[final, :, :, :]
                 else:
-                    slice = mean(data[(final - averagelast) : final, :, :, :], axis=0)
+                    data_slice = mean(
+                        data[(final - averagelast) : final, :, :, :], axis=0
+                    )
 
-                print(slice.shape)
+                print(data_slice.shape)
+                # This attribute results in the correct (x,y,z) dimension labels
+                data_slice.attributes["bout_type"] = "Field3D"
 
-                outfile.write(var, slice)
+                outfile.write(var, data_slice)
 
         infile.close()
         outfile.close()


### PR DESCRIPTION
- `nz` doesn't need to be a power of 2
- Ensure that `hist_hi` in restart files is a scalar, when read from `iteration` in dump files.
