### PR TITLE
Performance improvements

### DIFF
--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -115,7 +115,6 @@ def squashoutput(
     from boututils.boutarray import BoutArray
     import numpy
     import os
-    import gc
     import tempfile
     import shutil
     import glob
@@ -238,7 +237,6 @@ def squashoutput(
                 f.write(varname, var)
 
         var = None
-        # gc.collect()
 
     # Copy file attributes
     for attrname in outputs.list_file_attributes():

--- a/boutdata/squashoutput.py
+++ b/boutdata/squashoutput.py
@@ -238,7 +238,7 @@ def squashoutput(
                 f.write(varname, var)
 
         var = None
-        gc.collect()
+        # gc.collect()
 
     # Copy file attributes
     for attrname in outputs.list_file_attributes():
@@ -252,7 +252,6 @@ def squashoutput(
         f.close()
 
     del outputs
-    gc.collect()
 
     if delete:
         if append:

--- a/boutdata/tests/test_collect.py
+++ b/boutdata/tests/test_collect.py
@@ -24,6 +24,11 @@ from boutdata.tests.make_test_data import (
 
 collect_kwargs_list = [
     {"xguards": True, "yguards": "include_upper"},
+    {"xguards": False, "yguards": False},
+]
+
+collect_kwargs_list_full = [
+    {"xguards": True, "yguards": "include_upper"},
     {"xguards": False, "yguards": "include_upper"},
     {"xguards": True, "yguards": True},
     {"xguards": False, "yguards": True},
@@ -31,10 +36,10 @@ collect_kwargs_list = [
     {"xguards": False, "yguards": False},
 ]
 
+
 squash_params_list = [
     (False, {}),
     (True, {}),
-    (True, {"parallel": 2}),
 ]
 
 
@@ -290,12 +295,8 @@ class TestCollect:
         "time_split",
         [
             (1, None),
-            (2, None),
             (2, 3),
-            (3, None),
-            (4, None),
             (5, None),
-            (6, None),
             (7, None),
         ],
     )
@@ -874,11 +875,6 @@ class TestCollect:
             # {"parallel": False},
             {"parallel": 1},
             {"parallel": 2},
-            {"parallel": 3},
-            {"parallel": 4},
-            {"parallel": 5},
-            {"parallel": 6},
-            {"parallel": 7},
             {"parallel": 8},
             {"parallel": True},
         ),
@@ -1396,7 +1392,7 @@ class TestCollect:
         )
 
     @pytest.mark.parametrize("squash_params", squash_params_list)
-    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list)
+    @pytest.mark.parametrize("collect_kwargs", collect_kwargs_list_full)
     def test_connected_doublenull_min_files(
         self, tmp_path, squash_params, collect_kwargs
     ):
@@ -1736,13 +1732,6 @@ class TestCollect:
         [
             {},
             {"compress": True, "complevel": 1},
-            {"compress": True, "complevel": 2},
-            {"compress": True, "complevel": 3},
-            {"compress": True, "complevel": 4},
-            {"compress": True, "complevel": 5},
-            {"compress": True, "complevel": 5},
-            {"compress": True, "complevel": 7},
-            {"compress": True, "complevel": 8},
             {"compress": True, "complevel": 9},
         ],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = [
     "pytest",
-    "pytest-cov",
 ]
 docs = [
     "sphinx>=3.4,<5",
@@ -60,6 +59,3 @@ version = { attr = "setuptools_scm.get_version" }
 
 [tool.setuptools_scm]
 write_to = "boutdata/_version.py"
-
-[tool.pytest.ini_options]
-addopts = "--cov=boutdata"


### PR DESCRIPTION
[The first commit](https://github.com/boutproject/boutdata/commit/2c4500ed56199a55e098d84c399c5a6b3f27544e) is the most important one. For me it reduced the time from many, many hours to around 20 minutes.

2e095a22bec1114720086f3838a0ed36352a3be5 reduces the combinatory explosion. I don't think we need for example check the different compression levels. Maybe we can remove a bit more, or less. Anyway, that should make the unit tests faster. Beyond reducing, I think we would ne some fake datafile interface, but that would probably be more effort then it is worth.

18b4d4b36db2a65438137188935710cdf55d0fd3 removes the `--cov` flag - which makes it slightly faster. Mostly I assume most people don't care that much about coverage. If at all, it make sense to compare coverage before and after a change, but then one actually needs to look at the output ...

I think we should merge the first commit, happy to discuss and/or revert the other two ...