### PR TITLE
Fix creating restart files for BOUT++ 5

### DIFF
--- a/boutdata/data.py
+++ b/boutdata/data.py
@@ -695,9 +695,9 @@ class BoutOptionsFile(BoutOptions):
                         comments = []
                     if inline_comment is not None:
                         parent_section.inline_comments[sectionname] = inline_comment
-                        parent_section._comment_whitespace[
-                            sectionname
-                        ] = comment_whitespace
+                        parent_section._comment_whitespace[sectionname] = (
+                            comment_whitespace
+                        )
                 else:
                     # A key=value pair
 

--- a/boutdata/gen_surface.py
+++ b/boutdata/gen_surface.py
@@ -1,6 +1,7 @@
 """Flux surface generator for tokamak grid files
 
 """
+
 from __future__ import print_function
 
 import numpy as np

--- a/boutdata/restart.py
+++ b/boutdata/restart.py
@@ -527,6 +527,14 @@ def create(
                 # This attribute results in the correct (x,y,z) dimension labels
                 data_slice.attributes["bout_type"] = "Field3D"
 
+                # The presence of `time_dimension` triggers BOUT++ to
+                # save field with a time dimension, which breaks
+                # subsequent restart files. `current_time_index` just
+                # doesn't make sense for restart files
+                for bad_attr in ["current_time_index", "time_dimension"]:
+                    if bad_attr in data.attributes:
+                        data_slice.attributes.pop(bad_attr)
+
                 outfile.write(var, data_slice)
 
         infile.close()


### PR DESCRIPTION
BOUT++ v5 includes a `time_dimension` attribute for evolving fields. This must be removed when creating restart files from slices of dump files.