### PR TITLE
Added support for reading ADIOS2 BP files.

### DIFF
--- a/src/boutdata/collect.py
+++ b/src/boutdata/collect.py
@@ -1182,7 +1182,7 @@ def findFiles(path, prefix):
         prefix = prefix[:-1]
 
     # Look for parallel dump files
-    suffixes = [".nc", ".ncdf", ".cdl", ".h5", ".hdf5", ".hdf"]
+    suffixes = [".nc", ".ncdf", ".cdl", ".h5", ".hdf5", ".hdf", ".bp", ".bp5"]
     file_list_parallel = None
     suffix_parallel = ""
     for test_suffix in suffixes:


### PR DESCRIPTION
Notes:
- Read-only. It does not support `write` to BP files.

Tested with the elm-pb example, running the example with the `cbm18_dens8.grid_nx68ny64` mesh.

```
from boutdata import collect
from boutdata import griddata
from boututils.datafile import DataFile

# Read pressure “P” as a 4D [t,x,y,z] Numpy array:
p = collect("P", path="cbm18")

p.shape # -> (6, 68, 64, 16)

# Read the grid file
g = DataFile("cbm18_dens8.grid_nx68ny64.bp")

# g[“Rxy”] and g{“Zxy”] are 2D arrays [x, y] that specify the major radius (R) and height (Z)
# coordinates of the center of each cell, in meters

griddata.gridcontourf(g, p[-1,:,:,0])
```
Notes
- The data directory `cbm18` contains BOUT.dmp.bp in this case. 
- The same example works with using the NetCDF mesh instead of a (converted) ADIOS2 mesh file.