### PR TITLE
CI: Fix commit message and enable CI on fixing commit

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,4 +31,4 @@ jobs:
       run: ruff format .
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "[skip ci] Apply black/isort changes"
+        commit_message: "Apply ruff changes"


### PR DESCRIPTION
As we fail if `ruff check` fails, we should run again once we did run `ruff check --fix`