### PR TITLE
CI: Drop apt dependencies and switch to `uv`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,19 +27,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup prerequisites
-        run: sudo apt update &&
-             sudo apt install -y libhdf5-serial-dev
-                netcdf-bin
-                libnetcdf-dev
-                libsm6
-                libxext6
-                libxrender-dev
-                libxt6
-                libgl1-mesa-glx
-                libfontconfig
-                libxkbcommon-x11-0
-
       - name: Install dependencies
         run: |
           pip install .[tests]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -29,11 +34,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install .[tests]
+          uv pip install .[tests]
 
       - name: Test local run
         run: |
-          pytest -v
+          uv run pytest -v
 
       - name: Upload to codecov
         run: |
@@ -46,14 +51,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.11"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ruff
-    # Update output format to enable automatic inline annotations.
+
     - name: Run Ruff
-      run: ruff check --output-format=github .
+      run: uvx ruff check --output-format=github .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,6 @@ jobs:
         run: |
           uv run pytest -v
 
-      - name: Upload to codecov
-        run: |
-          pip install codecov
-          codecov
-
   lint:
     runs-on: ubuntu-latest
     if: always()


### PR DESCRIPTION
This fixes an issue with some of the apt packages no longer being available -- we don't need them anyway