### PR TITLE
Add `__repr__` to `BoutOptions`

### DIFF
--- a/src/boutdata/collect.py
+++ b/src/boutdata/collect.py
@@ -83,7 +83,7 @@ def _convert_to_nice_slice(r, N, name="range"):
         temp_slice = slice(N)
     elif isinstance(r, slice):
         temp_slice = r
-    elif isinstance(r, (int, np.integer)):
+    elif isinstance(r, int | np.integer):
         if r >= N or r < -N:
             # raise out of bounds error as if we'd tried to index the array with r
             # without this, would return an empty array instead

--- a/src/boutdata/data.py
+++ b/src/boutdata/data.py
@@ -479,6 +479,9 @@ class BoutOptions:
 
         return f.getvalue()
 
+    def __repr__(self):
+        return self.as_dict()
+
     def get_bool(self, name, default=None):
         """
         Convert an option value to a bool, in (almost) the same way as BOUT++.

--- a/src/boututils/datafile.py
+++ b/src/boututils/datafile.py
@@ -182,7 +182,7 @@ class DataFile:
         """
         if ranges is not None:
             for x in ranges:
-                if isinstance(x, (list, tuple)):
+                if isinstance(x, list | tuple):
                     x = slice(*x)
         return self.impl.read(name, ranges=ranges, asBoutArray=asBoutArray)
 

--- a/src/boututils/showdata.py
+++ b/src/boututils/showdata.py
@@ -423,9 +423,9 @@ def showdata(
     # Generate grids for plotting
     # Try to use provided grids where possible
     # If x and/or y are not lists, apply to all variables
-    if not isinstance(x, (list, tuple)):
+    if not isinstance(x, list | tuple):
         x = [x] * Nvar  # Make list of x with length Nvar
-    if not isinstance(y, (list, tuple)):
+    if not isinstance(y, list | tuple):
         y = [y] * Nvar  # Make list of x with length Nvar
     xnew = []
     ynew = []


### PR DESCRIPTION
(Includes #133)

I was getting annoyed that it was missing one. Returning the dict form
is the most sensible I think, at least it's the easiest to make sense
of in the terminal