### PR TITLE
Launch and shell wrappers

### DIFF
--- a/src/boututils/run_wrapper.py
+++ b/src/boututils/run_wrapper.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import re
 import subprocess
-from subprocess import PIPE, STDOUT, Popen, call
 
 if os.name == "nt":
     # Default on Windows

--- a/src/boututils/run_wrapper.py
+++ b/src/boututils/run_wrapper.py
@@ -50,15 +50,11 @@ def shell(command, pipe=False, env=None):
     """
 
     result = subprocess.run(
-        command,
-        shell=True,
-        capture_output=pipe,
-        env=env,
-        text=True
-        )
-    output = result.stdout if pipe else ''
+        command, shell=True, capture_output=pipe, env=env, text=True
+    )
+    output = result.stdout if pipe else ""
     if result.stderr:
-        output += '\nSTDERR:\n' + result.stderr
+        output += "\nSTDERR:\n" + result.stderr
     return result.returncode, output
 
 

--- a/src/boututils/run_wrapper.py
+++ b/src/boututils/run_wrapper.py
@@ -53,7 +53,7 @@ def shell(command, pipe=False, env=None):
     )
     output = result.stdout if pipe else ""
     if result.stderr:
-        output += "\nSTDERR:\n" + result.stderr
+        output = f"{output}\nSTDERR:\n{result.stderr}"
     return result.returncode, output
 
 

--- a/src/boututils/run_wrapper.py
+++ b/src/boututils/run_wrapper.py
@@ -226,7 +226,7 @@ def launch(
         cmd = f"{cmd} > {output}"
 
     # Set OMP_NUM_THREADS if mthread is provided (for OpenMP in BOUT++)
-    env = dict(os.environ)
+    env = os.environ.copy()
     if mthread:
         env["OMP_NUM_THREADS"] = str(mthread)
 


### PR DESCRIPTION
Use subprocess.run() instead of subprocess.Popen(), 
setting environment variables set with the env parameter. 

This change is required in order for tests to by run in parallel via pytest and xdist. 