### PR TITLE
Make .recalculate_xyz() optional, fix grid name parsing

### DIFF
--- a/src/boutdata/data.py
+++ b/src/boutdata/data.py
@@ -743,8 +743,12 @@ class BoutOptionsFile(BoutOptions):
                                 # Try to convert to float
                                 value = float(value)
                             except ValueError:
-                                # Leave as a string
-                                pass
+                                # Leave as a string, stripping surrounding quotes
+                                if len(value) >= 2 and (
+                                    (value[0] == '"' and value[-1] == '"')
+                                    or (value[0] == "'" and value[-1] == "'")
+                                ):
+                                    value = value[1:-1]
 
                         value_name = line[:eqpos].strip()
                         section[value_name] = value

--- a/src/boutdata/data.py
+++ b/src/boutdata/data.py
@@ -639,6 +639,7 @@ class BoutOptionsFile(BoutOptions):
         nx=None,
         ny=None,
         nz=None,
+        recalculate_xyz=True,
     ):
         BoutOptions.__init__(self, name)
         self.filename = filename
@@ -759,15 +760,16 @@ class BoutOptionsFile(BoutOptions):
                         section.inline_comments[value_name] = inline_comment
                         section._comment_whitespace[value_name] = comment_whitespace
 
-        try:
-            self.recalculate_xyz(nx=nx, ny=ny, nz=nz)
-        except Exception as e:
-            alwayswarn(
-                "While building x, y, z coordinate arrays, an "
-                "exception occured: "
-                + str(e)
-                + "\nEvaluating non-scalar options not available"
-            )
+        if recalculate_xyz:
+            try:
+                self.recalculate_xyz(nx=nx, ny=ny, nz=nz)
+            except Exception as e:
+                alwayswarn(
+                    "While building x, y, z coordinate arrays, an "
+                    "exception occured: "
+                    + str(e)
+                    + "\nEvaluating non-scalar options not available"
+                )
 
     def recalculate_xyz(self, *, nx=None, ny=None, nz=None):
         """


### PR DESCRIPTION
`BoutOptionsFile` has a method called `.recalculate_xyz` which is for evaluating input file expressions. It needs the coordinates, which it infers from the input file if nx/ny/nz are specified, or from the grid file if it's provided. In my use case, I never specify nx/ny/nz in the input file, and I don't supply a grid file when I just want to read a single setting. This causes a warning that recalculate_xyz didn't work.

I would honestly prefer that recalculate_xyz was not even done at the init stage, unless someone actually uses it actively? It seems like a more niche use case than just reading input settings which is very common.... 

This PR makes the method call optional, but `True` by default. But I would prefer to just get rid of it and make users call it separately if needed. 

I also found a grid name parsing issue:
https://github.com/boutproject/boutdata/blob/11f5d0acb3d92a30eb0f97866c206a238c487076/src/boutdata/data.py#L745-L747

If the user leaves quotation marks around the grid name, then BOUT++ will parse them out, but BoutOptionsFile will not, causing an error on reading. this PR strips the quotes.